### PR TITLE
docs: 修正框架对比表格和架构描述中的不实内容

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,21 @@
 
 <div align="center">
 
-| 能力 | Micro-Agent | LangGraph | AutoGen | OpenClaw |
+| 能力 | Micro-Agent | LangGraph | AutoGen¹ | OpenClaw |
 |:-----|:---:|:---:|:---:|:---:|
-| 开箱即用 API 服务 | ✅ | ❌ | ❌ | ❌ |
-| 垂域知识注入 (Skills) | ✅ | ❌ | ❌ | ❌ |
-| 内置 RAG 检索增强 | ✅ | ❌ | ❌ | ❌ |
-| 知识图谱增强 | ✅ | ❌ | ❌ | ❌ |
-| MCP 原生集成 | ✅ | 第三方 | 第三方 | 第三方 |
-| 流式 SSE 输出 | ✅ | ✅ | ❌ | ❌ |
+| 开箱即用 API 服务 | ✅ | ✅ | ❌ | ✅ |
+| 垂域知识注入 (Skills) | ✅ | ❌ | ❌ | ✅ |
+| 内置 RAG 检索增强 | ✅ | 生态 | 扩展 | ✅ |
+| MCP 集成 | ✅ | ✅ | ✅ | ✅ |
+| 流式 SSE 输出 | ✅ | ✅ | 需自建 | ✅ |
 | 多 LLM Profile 配置 | ✅ | ❌ | ❌ | ❌ |
 | 轻量（核心 <3K 行） | ✅ | ❌ | ❌ | ❌ |
 
 </div>
 
-**各框架定位：** Micro-Agent 面向垂域专业 Agent 服务交付 · LangGraph 面向复杂多步工作流编排 · AutoGen 面向多角色智能体协作 · OpenClaw 面向个人效率自动化
+> ¹ AutoGen 已进入维护模式，新项目建议使用 [Microsoft Agent Framework](https://github.com/microsoft/autogen)。
+
+**各框架定位：** Micro-Agent 面向垂域专业 Agent 服务交付 · LangGraph 面向复杂多步工作流编排 · AutoGen 面向多角色智能体协作 · OpenClaw 面向个人自主 AI 助手
 
 ## 架构
 
@@ -49,7 +50,6 @@
 - **Memory** — 会话记忆系统，支持短期记忆、文件持久化、跨会话恢复
 - **Skills** — 将领域规范、编码标准等知识注入 Agent 的 system prompt，使其具备专业能力
 - **RAG** — 从领域知识库中检索相关文档，为推理提供上下文
-- **Knowledge Graph** — 基于图结构的领域知识表示与关联推理
 - **MCP / Tools** — 通过 [Model Context Protocol](https://modelcontextprotocol.io) 连接外部工具和数据源
 
 ## 快速开始


### PR DESCRIPTION
## Summary

基于对 LangGraph、AutoGen、OpenClaw 的实际调研，修正 README 中框架对比表格和架构描述的不实内容：

- 修正 LangGraph：已有 LangGraph Platform 提供 API 服务，MCP 通过官方 langchain-mcp-adapters 支持
- 修正 AutoGen：MCP 通过官方 autogen_ext.tools.mcp 支持，有 GraphRAG 扩展；标注已进入维护模式
- 修正 OpenClaw：有 OpenAI 兼容 API、内置 RAG、SOUL.md + ClawHub 技能系统、原生 MCP、SSE 流式
- 移除"知识图谱增强"行：代码中未实现，仅有 rag/base.py 注释中的未来方向
- 移除架构描述中的 Knowledge Graph 组件

## Test plan

- [ ] 确认对比表格内容与各框架实际能力一致
- [ ] 确认架构描述不再包含未实现的功能


Made with [Cursor](https://cursor.com)