### PR TITLE
fix: 修复部署容器中 uvicorn 未安装的问题

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir -e ".[all]"
 
 EXPOSE 8010 22 8000
 


### PR DESCRIPTION
## Summary
- `deploy/Dockerfile` 中 `pip install -e .` 只安装了基础依赖，`uvicorn` 属于 `[api]` 可选依赖组未被安装，导致容器启动时报 `uvicorn: command not found`
- 改为 `pip install -e ".[all]"` 安装全部可选依赖，与根目录 `Dockerfile` 保持一致

## Test plan
- [ ] CI 通过
- [ ] 重新部署后容器正常启动，`uvicorn` 可用