### PR TITLE
fix: EmbeddingRetriever 传入 base_url 以支持代理访问

### DIFF
--- a/api/routes/agent.py
+++ b/api/routes/agent.py
@@ -102,6 +102,7 @@ async def _get_packaging_retriever():
         model=config.rag.embedding_model,
         chunk_size=config.rag.chunk_size,
         api_key=config.llm.api_key,
+        base_url=config.llm.base_url,
     )
     await _packaging_retriever.load_directory(knowledge_dir)
     return _packaging_retriever
@@ -427,6 +428,7 @@ async def _get_aml_retriever():
         model=config.rag.embedding_model,
         chunk_size=250,
         api_key=config.llm.api_key,
+        base_url=config.llm.base_url,
     )
     await _aml_retriever.load_directory(knowledge_dir)
     return _aml_retriever


### PR DESCRIPTION
## Summary
- `EmbeddingRetriever` 创建时补充传入 `base_url=config.llm.base_url`，使 Embedding 调用也走 LLM 配置的代理地址

## Test plan
- [ ] 验证 Embedding 调用不再报 Connection error