### PR TITLE
[codex] use sha tag for agent deploy

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,7 +55,8 @@ jobs:
     steps:
       - name: Trigger deploy webhook
         run: |
+          SHORT_SHA=${GITHUB_SHA::7}
           curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"service":"agent","image":"${{ secrets.DOCKER_HUB_USERNAME }}/micro-agent:latest"}'
+            -d "{\"service\":\"agent\",\"image\":\"${{ secrets.DOCKER_HUB_USERNAME }}/micro-agent:${SHORT_SHA}\"}"


### PR DESCRIPTION
## Summary
- deploy Micro-Agent using the commit short SHA image tag instead of `latest`
- keep publishing both `latest` and short SHA tags for compatibility

## Why
The deploy server can see stale `latest` images through Docker Hub/mirrors. Sending an immutable short SHA tag lets the deploy script fetch the exact CI artifact, then retag it for compose.

## Validation
- Parsed `.github/workflows/master.yml` as YAML
- Pushed branch `codex/deploy-agent-sha-tag`

## Notes
Server `fdueblab` has already been manually updated to `micro-agent:d31fde9` and verified against image ID `sha256:37b16e...`.
