### PR TITLE
test: 兼容 FastAPI 路由检查

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,7 +114,7 @@ async def test_fastapi_import():
     from api.app import app
     assert app.title == "Micro-Agent V2"
 
-    routes = [r.path for r in app.routes]
+    routes = list(app.openapi()["paths"].keys())
     assert "/api/tasks" in routes or any("/api/tasks" in r for r in routes)
     assert "/health" in routes
 

--- a/tests/test_meta_app.py
+++ b/tests/test_meta_app.py
@@ -211,6 +211,6 @@ def test_event_to_legacy():
 
 def test_app_includes_agent_endpoints():
     from api.app import app
-    paths = [r.path for r in app.routes]
+    paths = list(app.openapi()["paths"].keys())
     assert any("/api/agent/meta_app/run" in p for p in paths)
     assert any("/api/agent/capability_describe" in p for p in paths)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -125,5 +125,5 @@ def test_agent_router_import():
 
 def test_app_includes_agent_router():
     from api.app import app
-    paths = [r.path for r in app.routes]
+    paths = list(app.openapi()["paths"].keys())
     assert any("/api/agent" in p for p in paths)


### PR DESCRIPTION
改用 OpenAPI paths 校验已注册接口，避免新版 FastAPI 内部路由对象缺少 path 属性导致 CI 失败。

