### PR TITLE
[codex] gate PyPI publish tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   publish:
     name: Build & Publish
+    # Platform production releases use vYYYY.MM.DD and should only deploy Docker.
+    # PyPI package releases must use sdk-vX.Y.Z to avoid weekly platform releases
+    # publishing the Python SDK by accident.
+    if: startsWith(github.event.release.tag_name, 'sdk-v')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## What changed

- Added an `sdk-v` tag prefix gate to the PyPI publish workflow.

## Why

Platform production releases use `vYYYY.MM.DD` tags to deploy Docker images. Those releases should not publish the Python SDK to PyPI. SDK/package releases can still use `sdk-vX.Y.Z` tags.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "publish.yml ok"'`
- `git diff --check`
