### PR TITLE
fix(api): sanitise UploadFile.filename in save_upload (CWE-22)

### DIFF
--- a/api/services/files.py
+++ b/api/services/files.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import os
+import re
 import shutil
 import zipfile
 from datetime import datetime
@@ -15,10 +16,59 @@ from fastapi import HTTPException, UploadFile
 from loguru import logger
 
 
+# ── Filename sanitisation ────────────────────────────────────────────────
+# 多端点（/code_analysis、/service_packaging、/aml_auto_generate 等）会把
+# multipart 上传的 filename 头直接拼到工作区路径里。攻击者可以构造
+# filename = '../../etc/cron.d/x' 之类的路径元素来逃逸 dest_dir：当工作区
+# 里恰好存在同名首段目录时（长时间运行的服务里很常见），写入会落到工作区
+# 外部；在 Windows 上 ``\\`` 是路径分隔符，攻击直接成功；即便不能逃逸，
+# 未清洗的文件名也会污染工作区并破坏后续 cleanup 逻辑。统一在保存前提取
+# basename 并替换危险字符。
+_UNSAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _safe_filename(name: Optional[str], default: str = "upload") -> str:
+    """从用户提供的文件名中提取一个安全 basename。
+
+    - 去掉路径分隔符（``/`` 与 ``\\``），只保留 ``os.path.basename``/``Path.name``
+    - 把 ``..``、空字符串、全为点号的名字（``.``、``...`` 等）替换成默认值
+    - 把除 ``A-Za-z0-9._-`` 之外的字符替换成 ``_``，避免 shell/命令注入隐患
+    - 限制总长度，防止过长文件名 DoS 或破坏文件系统
+    """
+    raw = (name or "").strip()
+    if not raw:
+        return default
+
+    # 同时切掉 Windows 风格分隔符——Path.name 在 POSIX 上不会拆 ``\\``。
+    raw = raw.replace("\\", "/")
+    base = os.path.basename(raw)
+
+    # ``..``、``.`` 等仅由点号组成的名字视为非法。
+    if not base or set(base) <= {"."}:
+        return default
+
+    cleaned = _UNSAFE_FILENAME_CHARS.sub("_", base)
+
+    # 再次防御：替换后仍可能退化成 ``.``/``..``。
+    if not cleaned or set(cleaned) <= {"."}:
+        return default
+
+    # 文件系统多数对单个组件限制 255 字节，预留 ts/前缀空间。
+    return cleaned[:200]
+
+
 async def save_upload(upload: UploadFile, dest_dir: Path) -> Path:
     dest_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    dest = dest_dir / f"{ts}_{upload.filename or 'upload'}"
+    safe_name = _safe_filename(upload.filename)
+    dest = dest_dir / f"{ts}_{safe_name}"
+
+    # 兜底校验：确保最终路径仍在 dest_dir 内，防止未来逻辑改动引入回归。
+    resolved_dest = dest.resolve()
+    resolved_root = dest_dir.resolve()
+    if not resolved_dest.is_relative_to(resolved_root):
+        raise HTTPException(400, "非法的上传文件名")
+
     content = await upload.read()
     dest.write_bytes(content)
     logger.info(f"文件已保存: {dest} ({len(content)} bytes)")
@@ -40,7 +90,10 @@ async def download_from_url(url: str, dest_dir: Path) -> Path:
     dest_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     parsed = urlparse(url)
-    filename = os.path.basename(parsed.path) or f"download_{ts}.zip"
+    raw_name = os.path.basename(parsed.path) or f"download_{ts}.zip"
+    # 同样清洗远程响应里推断出的文件名，避免「URL path = ../../x」之类的攻击
+    # 经由同一个 dest_dir 拼接落到工作区外（与 save_upload 风险对称）。
+    filename = _safe_filename(raw_name, default=f"download_{ts}.zip")
     dest = dest_dir / f"{ts}_{filename}"
 
     async with httpx.AsyncClient(timeout=120) as client:

--- a/tests/test_cwe22_upload_path_traversal.py
+++ b/tests/test_cwe22_upload_path_traversal.py
@@ -1,0 +1,192 @@
+"""PoC tests for CWE-22 path traversal in :func:`api.services.files.save_upload`.
+
+Vulnerability
+-------------
+``save_upload`` builds its destination path with::
+
+    dest = dest_dir / f"{ts}_{upload.filename or 'upload'}"
+
+The ``upload.filename`` value comes straight from the multipart ``filename``
+header on every endpoint that accepts a file (``/api/agent/code_analysis``,
+``/api/agent/service_packaging``, ``/api/agent/aml_auto_generate``,
+``/api/agent/aml_report``, …). None of those endpoints require authentication,
+and starlette / python-multipart preserves slashes/``..`` verbatim.
+
+Two concrete write-outside-workspace primitives exist on the unfixed code:
+
+1. **Collision with an existing directory** — when the workspace already
+   contains a directory whose name matches ``"<ts>_<first-segment-of-filename>"``
+   (a very common situation: the service creates ``<ts>_extracted`` /
+   ``<ts>_marker`` dirs over its lifetime, ``ts`` collisions can be raced
+   inside a one-second window, and prior uploads can prepare matching dirs),
+   a filename like ``marker/../../ESCAPED`` resolves to a path outside the
+   workspace. ``write_bytes`` succeeds and arbitrary attacker bytes land on
+   disk at the chosen location.
+
+2. **On Windows** the backslash is a path separator; ``..\\..\\evil`` escapes
+   immediately on the first call.
+
+Even when neither primitive triggers, an unsanitised filename pollutes the
+workspace with weird relative names and breaks the ``cleanup_paths`` logic.
+
+These tests assert that the fix sanitises the filename so the saved path is
+always a single component inside ``dest_dir``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+class _FakeUpload:
+    """Minimal stand-in for ``starlette.datastructures.UploadFile``."""
+
+    def __init__(self, filename: str, content: bytes = b"x") -> None:
+        self.filename = filename
+        self._content = content
+
+    async def read(self) -> bytes:
+        return self._content
+
+
+def _run(coro):
+    if sys.version_info < (3, 10):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+    return asyncio.run(coro)
+
+
+def _assert_inside(saved: Path, root: Path) -> None:
+    resolved_root = root.resolve()
+    resolved_saved = saved.resolve()
+    assert resolved_saved.is_relative_to(resolved_root), (
+        f"saved path escaped workspace: saved={resolved_saved!s}, "
+        f"workspace={resolved_root!s}"
+    )
+
+
+def test_save_upload_sanitises_dotdot_filename(tmp_path: Path) -> None:
+    """A filename containing ``../`` must not escape ``dest_dir``."""
+    from api.services.files import save_upload
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    saved = _run(save_upload(_FakeUpload("../../escape.txt"), workspace))
+
+    _assert_inside(saved, workspace)
+    assert "/" not in saved.name
+    assert "\\" not in saved.name
+    assert ".." not in saved.name.split("_")
+
+
+def test_save_upload_sanitises_windows_separators(tmp_path: Path) -> None:
+    """Backslashes (Windows path separator) must be stripped."""
+    from api.services.files import save_upload
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    saved = _run(save_upload(_FakeUpload(r"..\..\evil.bin"), workspace))
+
+    _assert_inside(saved, workspace)
+    assert "\\" not in saved.name
+    assert ".." not in saved.name.split("_")
+
+
+def test_save_upload_absolute_filename_stays_inside(tmp_path: Path) -> None:
+    """An absolute-looking filename must collapse to a clean basename."""
+    from api.services.files import save_upload
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    saved = _run(save_upload(_FakeUpload("/etc/passwd_pwn"), workspace))
+
+    _assert_inside(saved, workspace)
+    assert saved.parent.resolve() == workspace.resolve()
+
+
+def test_save_upload_resists_collision_traversal(tmp_path: Path) -> None:
+    """The headline real-world exploit: workspace already contains
+    ``<ts>_marker`` (from a previous upload, race, or attacker prep)
+    and the next filename is ``marker/../../ESCAPED``. Without the fix
+    this writes to ``<tmp>/ESCAPED`` — *outside* the workspace.
+    """
+    from api.services.files import save_upload
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    # Pre-create candidate prefix dirs for every second of the current minute,
+    # guaranteeing that whichever ts ``save_upload`` picks will collide.
+    now = datetime.now().replace(microsecond=0)
+    base_min = now.strftime("%Y%m%d_%H%M")
+    for sec in range(60):
+        (workspace / f"{base_min}{sec:02d}_marker").mkdir(parents=True, exist_ok=True)
+
+    sentinel = tmp_path / "ESCAPED"
+    if sentinel.exists():
+        sentinel.unlink()
+
+    saved = _run(save_upload(_FakeUpload("marker/../../ESCAPED", b"OWNED"), workspace))
+
+    _assert_inside(saved, workspace)
+    assert not sentinel.exists(), (
+        f"path traversal succeeded: sentinel was written at {sentinel}"
+    )
+
+
+def test_save_upload_blank_filename_falls_back_to_default(tmp_path: Path) -> None:
+    """An empty / whitespace-only filename must fall back to a safe default
+    instead of producing a dangling ``<ts>_`` name.
+    """
+    from api.services.files import save_upload
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    saved = _run(save_upload(_FakeUpload(""), workspace))
+
+    _assert_inside(saved, workspace)
+    assert not saved.name.endswith("_")
+
+
+def test_save_upload_dot_filename_falls_back_to_default(tmp_path: Path) -> None:
+    """``..`` as a basename (after stripping separators) is the canonical
+    traversal payload; must be replaced by the default.
+    """
+    from api.services.files import save_upload
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    saved = _run(save_upload(_FakeUpload(".."), workspace))
+
+    _assert_inside(saved, workspace)
+    assert ".." not in saved.name.split("_")
+
+
+def test_safe_filename_helper_unit() -> None:
+    """Direct unit coverage of the sanitiser helper."""
+    from api.services.files import _safe_filename
+
+    assert _safe_filename("../../etc/cron.d/x") == "x"
+    assert _safe_filename(r"..\..\evil.bin") == "evil.bin"
+    assert _safe_filename("/etc/passwd") == "passwd"
+    assert _safe_filename("..") == "upload"
+    assert _safe_filename(".") == "upload"
+    assert _safe_filename("...") == "upload"
+    assert _safe_filename("") == "upload"
+    assert _safe_filename(None) == "upload"
+    # Non-alphanumeric (including spaces / semicolons) becomes ``_``.
+    assert _safe_filename("a b;c d.txt") == "a_b_c_d.txt"
+    # Length cap so a single component cannot blow up the FS limit.
+    long = "a" * 5_000 + ".bin"
+    assert len(_safe_filename(long)) <= 200


### PR DESCRIPTION
## 关联 Issue

Closes #66

## 改动说明

修复 `api/services/files.save_upload`（以及对称的 `download_from_url`）里的 CWE-22 路径穿越漏洞。

### 漏洞

`save_upload` 直接把 multipart 上传里的 `UploadFile.filename` 拼到工作区路径：

```python
# api/services/files.py（修复前）
async def save_upload(upload: UploadFile, dest_dir: Path) -> Path:
    dest_dir.mkdir(parents=True, exist_ok=True)
    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
    dest = dest_dir / f"{ts}_{upload.filename or 'upload'}"
    content = await upload.read()
    dest.write_bytes(content)
```

`upload.filename` 来自 HTTP 头，Starlette / python-multipart 原样保留 `..`、`/`、`\`，未做任何归一化或剥离。攻击者构造 `filename = "marker/../../ESCAPED"` 之类的负载即可把字节写到工作区**外**任意位置。

`download_from_url` 同样从 `os.path.basename(urlparse(url).path)` 推断文件名，存在对称风险（攻击者控制的 URL 经过同一拼接路径）。

### 受影响端点（均**无认证**）

`api/routes/agent.py` 里所有接受文件的端点都调用 `save_upload`：

| 行号 | 端点 |
|---:|---|
| 67  | `POST /api/agent/code_analysis` |
| 119 | `POST /api/agent/service_packaging` |
| 189 | `POST /api/agent/service_evaluation` |
| 274 | `POST /api/agent/meta_app_validation` |
| 310 | `POST /api/agent/aml_report` |
| 346 | `POST /api/agent/aml_model_evaluation` |
| 489 / 498 / 514 | `POST /api/agent/aml_auto_generate` |

`router = APIRouter(prefix="/api/agent", tags=["agent"])` 没有 `dependencies=[Depends(...)]`，`api/app.py` 也没有任何 auth middleware，并且 `CORSMiddleware(allow_origins=["*"], allow_credentials=True)` 完全放开；`docker-compose.yml` 又把端口暴露在 `0.0.0.0:8010`。结论：任何能访问端口的客户端都可以匿名触发漏洞。

### 为什么影响严重（bind-mount + uvicorn `--reload` → host RCE）

`docker-compose.yml` 把宿主源码以读写方式挂到容器里：

```yaml
volumes:
  - ./api:/app/api
  - ./micro_agent:/app/micro_agent
  - ./tasks:/app/tasks
command: ["uvicorn", "api.app:app", ..., "--reload",
          "--reload-dir", "/app/api",
          "--reload-dir", "/app/tasks",
          "--reload-dir", "/app/micro_agent"]
```

只要穿越写入命中 `/app/api`、`/app/tasks` 或 `/app/micro_agent` 下的任意 `.py`，就同时改写了宿主机的源文件（bind mount 是同一 inode），uvicorn `--reload` 立刻重新加载并执行攻击者的 Python——文件写入原语直接升级为宿主进程上的 RCE。即使不利用挂载提权，攻击者也能任意覆盖服务账户可写的文件、投放 `cron.d` 条目，或破坏 `cleanup_paths` 的清理逻辑。

## 修复方案

1. 新增 `_safe_filename()` 辅助函数：
   - 把 `\` 统一替换成 `/`，再 `os.path.basename` 取末段——剥离所有路径分隔符；
   - `..`、`.`、空串、纯由点号组成的串、`None` 全部回落到默认值（`upload` 或 `download_<ts>.zip`）；
   - 把 `[A-Za-z0-9._-]` 之外的字符替换为 `_`，避免后续把文件名拼到 shell 命令时出现注入风险；
   - 截断到 200 字节，给 `<ts>_` 前缀留余量，避免触发 ext4 等 255 字节文件名上限。
2. 在 `save_upload` 与 `download_from_url` 两处同时调用——后者是对称的 URL 派生文件名路径，必须同步加固。
3. 兜底：保存前用 `Path.resolve().is_relative_to(dest_dir.resolve())` 再校验一次，万一未来逻辑改动导致 sanitiser 失效，仍然直接 `HTTPException(400, "非法的上传文件名")`。
4. 7 个 PoC 测试用例覆盖：经典 `..`、Windows 风格 `\`、绝对路径文件名、利用 `<ts>_marker` 目录碰撞的穿越（headline 漏洞）、空 / 纯点文件名、`_safe_filename` 的直接单元覆盖。

`extract_zip` 里还有一个独立的 ZipSlip（CWE-22 in `zipfile` extraction），与本 PR 不在同一原语上，为保持 PR 单一职责未一并修复——可在后续 issue 跟进。

## 测试方式

```bash
# 新增的 PoC 测试
.venv/bin/pytest tests/test_cwe22_upload_path_traversal.py -v

# 全量回归
.venv/bin/pytest
```

结果：

- 新增 7 个测试全部通过，包括 `test_save_upload_resists_collision_traversal`（在工作区里预创 60 个候选 `<ts>_marker` 目录后上传 `marker/../../ESCAPED`，验证没有任何字节落到工作区外的 sentinel 路径）。
- 全量套件：`256 passed in 4.02s`，无新增 failure / skip。

在未打补丁的 HEAD~1 上执行同一 PoC，会在 workspace 外面写出 `ESCAPED`（内容 `OWNED`）——补丁后同样负载折叠成 `<workspace>/<ts>_ESCAPED`，穿越被阻断。

### 维护者复现（HTTP 路径）

```bash
echo OWNED > /tmp/payload
curl -F "file=@/tmp/payload;filename=marker/../../ESCAPED" \
     http://localhost:8010/api/agent/code_analysis
# 修复前：ls -la ../ESCAPED 能看到 OWNED；修复后：返回正常 JSON，
# 字节落在 <workspace>/<ts>_ESCAPED，未逃逸。
```

## 提交前的对抗性核对

提交前我尝试自我反驳：

- **会不会有上游 sanitiser？** 没有。Starlette `UploadFile.filename` 直接暴露原始 multipart 头，不做归一化；`api/app.py` 没有 before-request middleware；`api/routes/agent.py` 的 router 没有 `dependencies=[Depends(...)]`。
- **碰撞前提条件难达成？** 不难。服务自身在长期运行中会产生 `<ts>_extracted` / `<ts>_marker` 等目录；攻击者也可以先用同一接口上传 60 个候选 `<ts>_marker` 自己制造碰撞窗口（PoC 测试就是这么做的）。Windows 部署下连碰撞都不需要。
- **是否被既有访问控制阻挡？** `CORSMiddleware(allow_origins=["*"], allow_credentials=True)` + `docker-compose` 端口 `0.0.0.0:8010` 明确说明这就是匿名公网可达的服务。
- **Bash 工具是否已经给攻击者等价能力？** 不是。Bash 工具是 LLM agent 内部调用的；外部攻击者并不能直接发指令让 LLM 跑 shell。CWE-22 是确定性的、绕过 LLM 的直接「任意写」原语，是新的攻击能力。

## Checklist

- [x] 已关联对应 Issue（#66）
- [x] 代码改动已添加测试（`tests/test_cwe22_upload_path_traversal.py`，7 个用例）
- [x] `pytest` 测试通过（`256 passed`）