### PR TITLE
feat: restore agentic MCP packaging workflow

### DIFF
--- a/api/routes/agent.py
+++ b/api/routes/agent.py
@@ -2,7 +2,7 @@
 
 端点列表（与旧版一一对应）：
   POST /api/agent/code_analysis              文件上传 → 代码分析
-  POST /api/agent/service_packaging          文件上传 → 服务封装（含 ZIP 回传 + 会话记忆）
+  POST /api/agent/service_packaging          文件上传 → Agent 服务封装（含 ZIP 回传）
   POST /api/agent/mcp_test                   表单 → MCP 测试
   POST /api/agent/service_evaluation         表单+文件 → 服务评测
   POST /api/agent/service_upgrade_advice     表单 → 成果升级建议
@@ -53,6 +53,12 @@ from micro_agent.core.config import config
 from micro_agent.core.llm import LLM
 from micro_agent.core.mcp_agent import MCPAgent
 from micro_agent.core.schema import AgentEvent
+from micro_agent.packaging.analyzer import RepositoryAnalyzer
+from micro_agent.packaging.workflow import (
+    AgenticAnalysisWorkflow,
+    AgenticPackagingWorkflow,
+    analysis_cache,
+)
 from micro_agent.meta_app import PublishedMetaAppError, load_published_artifact
 from micro_agent.simulation.artifact_runtime import run_artifact
 from micro_agent.task.base import get_task, list_tasks, render_prompt
@@ -72,51 +78,31 @@ WORKSPACE = str(config.workspace)
 
 @router.post("/code_analysis")
 async def code_analysis(file: UploadFile = File(...)):
-    saved = await save_upload(file, Path(WORKSPACE))
-    project_dir = resolve_project_dir(saved, Path(WORKSPACE))
-    main_code = find_main_file(project_dir)
-
-    prompt = render_prompt(
-        "code_analysis.md.j2",
-        workspace=WORKSPACE, input_dir=project_dir, main_code=main_code,
-        temp_dir="temp", function_info_path="function.json",
-    )
-    agent, _ = await build_agent(name="code_analysis", system_prompt=get_task("code_analysis").system_prompt)
-    ctx = await task_manager.submit(agent, prompt)
+    job_root = Path(WORKSPACE) / "temp" / f"mcp-analysis-{uuid.uuid4().hex}"
+    saved = await save_upload(file, job_root / "upload")
+    project_dir = resolve_project_dir(saved, job_root / "input")
+    ir = RepositoryAnalyzer().analyze(project_dir)
+    graph_path = job_root / "function.json"
+    workflow = AgenticAnalysisWorkflow(project_dir=project_dir, ir=ir, graph_path=graph_path)
+    ctx = await task_manager.submit(workflow, file.filename or "uploaded repository")
 
     return await sse_response(
         ctx,
-        output_files=[{"name": "function", "file": f"{WORKSPACE}/temp/function.json"}],
-        cleanup=partial(cleanup_paths, str(saved), project_dir),
+        output_files=[{"name": "function", "file": str(graph_path)}],
+        cleanup=partial(cleanup_paths, job_root),
+        components_meta={
+            "engine": "agentic",
+            "phase": "semantic_planning",
+            "repository_fingerprint": ir.fingerprint,
+            "files_scanned": len(ir.files),
+            "symbols_scanned": len(ir.symbols),
+        },
     )
 
 
 # ============================================================
-#  端点：服务封装（支持会话记忆 + Skills + RAG）
+#  端点：Agent 语义规划、实现与验收
 # ============================================================
-
-_packaging_retriever = None
-
-
-async def _get_packaging_retriever():
-    """延迟初始化服务封装知识库检索器（模块级单例）。"""
-    global _packaging_retriever
-    if _packaging_retriever is not None:
-        return _packaging_retriever
-
-    knowledge_dir = Path(config.workspace) / "knowledge" / "service_packaging"
-    if not knowledge_dir.exists():
-        return None
-
-    from micro_agent.core.rag.embedding import EmbeddingRetriever
-    _packaging_retriever = EmbeddingRetriever(
-        model=config.rag.embedding_model,
-        chunk_size=config.rag.chunk_size,
-        api_key=config.llm.api_key,
-        base_url=config.llm.base_url,
-    )
-    await _packaging_retriever.load_directory(knowledge_dir)
-    return _packaging_retriever
 
 
 @router.post("/service_packaging")
@@ -124,51 +110,38 @@ async def service_packaging(
     file: UploadFile = File(...),
     session_id: Optional[str] = Form(default=None),
 ):
-    saved = await save_upload(file, Path(WORKSPACE))
-    project_dir = resolve_project_dir(saved, Path(WORKSPACE))
-    main_code = find_main_file(project_dir)
-    output_dir = f"{WORKSPACE}/app-demo-output"
-
-    retriever = await _get_packaging_retriever()
-
-    skill_names = ["mcp_protocol", "docker_packaging", "code_analysis_patterns"]
-    llm_profile = "reasoning"
-
-    agent, sid = await build_agent(
-        name="service_packaging",
-        system_prompt=get_task("service_packaging").system_prompt,
-        max_steps=40,
-        llm_profile=llm_profile,
-        enable_session=True,
-        session_id=session_id,
-        skills=skill_names,
-        retriever=retriever,
+    job_root = Path(WORKSPACE) / "temp" / f"mcp-package-{uuid.uuid4().hex}"
+    saved = await save_upload(file, job_root / "upload")
+    project_dir = resolve_project_dir(saved, job_root / "input")
+    ir = RepositoryAnalyzer().analyze(project_dir)
+    output_dir = job_root / "artifact"
+    cached_plan = analysis_cache.get(ir.fingerprint)
+    response_session_id = session_id or uuid.uuid4().hex
+    workflow = AgenticPackagingWorkflow(
+        project_dir=project_dir,
+        ir=ir,
+        artifact_dir=output_dir,
+        plan=cached_plan,
     )
-
-    components_meta = {
-        "skills": skill_names,
-        "llm_profile": llm_profile,
-        "llm_model": config.get_llm(llm_profile).model,
-        "rag_ready": retriever is not None and len(retriever._docs) > 0,
-        "rag_docs_count": len(retriever._docs) if retriever else 0,
-        "memory_loaded": len(agent.memory) if sid and session_id else 0,
-        "session_id": sid,
-        "session_resumed": bool(session_id),
-    }
-
-    prompt = render_prompt(
-        "service_packaging.md.j2",
-        workspace=WORKSPACE, input_dir=project_dir, main_code=main_code,
-        output_dir=output_dir, temp_dir="temp", function_info_path="function.json",
-    )
-    ctx = await task_manager.submit(agent, prompt)
+    ctx = await task_manager.submit(workflow, file.filename or "uploaded repository")
 
     return await sse_response(
         ctx,
-        zip_dir=output_dir,
-        cleanup=partial(cleanup_paths, str(saved), project_dir),
-        session_id=sid,
-        components_meta=components_meta,
+        zip_dir=str(output_dir),
+        ready_marker=str(output_dir / ".ioeb-ready"),
+        cleanup=partial(cleanup_paths, job_root),
+        session_id=response_session_id,
+        components_meta={
+            "engine": "agentic",
+            "phase": "implementation_and_verification",
+            "llm_profile": "reasoning",
+            "llm_model": config.get_llm("reasoning").model,
+            "repository_fingerprint": ir.fingerprint,
+            "analysis_cache_hit": cached_plan is not None,
+            "session_id": response_session_id,
+            "max_repair_attempts": workflow.max_repairs,
+            "host_bash_enabled": False,
+        },
     )
 
 

--- a/api/services/files.py
+++ b/api/services/files.py
@@ -6,9 +6,11 @@ import base64
 import os
 import re
 import shutil
+import stat
 import zipfile
 from datetime import datetime
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Optional
 
 import httpx
@@ -76,9 +78,47 @@ async def save_upload(upload: UploadFile, dest_dir: Path) -> Path:
 
 
 def extract_zip(zip_path: Path, dest_dir: Path) -> Path:
+    """Safely extract an untrusted uploaded repository ZIP."""
+    max_entries = 10_000
+    max_uncompressed_bytes = 2_000_000_000
+    max_compression_ratio = 200.0
     dest_dir.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(zip_path, "r") as zf:
-        zf.extractall(dest_dir)
+    root = dest_dir.resolve()
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            members = zf.infolist()
+            if len(members) > max_entries:
+                raise ValueError("ZIP 文件条目过多")
+            total = 0
+            for member in members:
+                normalized = member.filename.replace("\\", "/")
+                relative = PurePosixPath(normalized)
+                if (
+                    relative.is_absolute()
+                    or ".." in relative.parts
+                    or (relative.parts and ":" in relative.parts[0])
+                ):
+                    raise ValueError(f"ZIP 包含不安全路径: {member.filename}")
+                mode = member.external_attr >> 16
+                if stat.S_ISLNK(mode):
+                    raise ValueError(f"ZIP 不允许符号链接: {member.filename}")
+                total += member.file_size
+                if total > max_uncompressed_bytes:
+                    raise ValueError("ZIP 解压后大小超过限制")
+                if member.file_size / max(member.compress_size, 1) > max_compression_ratio:
+                    raise ValueError(f"ZIP 条目压缩比异常: {member.filename}")
+                target = (dest_dir / normalized).resolve()
+                if not target.is_relative_to(root):
+                    raise ValueError(f"ZIP 包含越界路径: {member.filename}")
+                if member.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(member) as source, target.open("wb") as destination:
+                    shutil.copyfileobj(source, destination)
+    except (OSError, ValueError, zipfile.BadZipFile) as exc:
+        shutil.rmtree(dest_dir, ignore_errors=True)
+        raise HTTPException(400, f"无法安全解压 ZIP: {exc}") from exc
     logger.info(f"ZIP 已解压: {zip_path} -> {dest_dir}")
     return dest_dir
 

--- a/api/services/sse.py
+++ b/api/services/sse.py
@@ -54,6 +54,7 @@ async def sse_response(
     *,
     output_files: Sequence[OutputFileSpec] | None = None,
     zip_dir: str | None = None,
+    ready_marker: str | None = None,
     cleanup: Callable[[], None] | None = None,
     session_id: str | None = None,
     components_meta: dict | None = None,
@@ -64,6 +65,7 @@ async def sse_response(
         ctx: TaskManager.submit() 返回的 TaskContext
         output_files: 任务完成后需要读取的输出文件列表
         zip_dir: 如果非空，任务完成后将此目录打包为 ZIP base64 返回
+        ready_marker: 若提供，则只有该验收标记存在时才允许打包 zip_dir
         cleanup: finally 阶段执行的清理回调
         session_id: 会话 ID，通过 header 返回给前端
     """
@@ -106,7 +108,8 @@ async def sse_response(
             final: dict[str, Any] = {"is_last": True, "is_final_result": True}
             final_results: dict[str, Any] = {}
 
-            if zip_dir and os.path.isdir(zip_dir):
+            artifact_ready = not ready_marker or os.path.isfile(ready_marker)
+            if zip_dir and os.path.isdir(zip_dir) and artifact_ready:
                 try:
                     zip_path = Path(zip_dir)
                     final_results["service_package"] = pack_directory_as_zip_base64(zip_dir)
@@ -116,6 +119,8 @@ async def sse_response(
                     ]
                 except Exception as e:
                     final_results["error"] = f"压缩目录失败: {e}"
+            elif zip_dir and not artifact_ready:
+                final_results["error"] = "服务产物未通过验收，已阻止打包和部署"
 
             if output_files and not zip_dir:
                 for spec in output_files:

--- a/micro_agent/packaging/__init__.py
+++ b/micro_agent/packaging/__init__.py
@@ -1,0 +1,16 @@
+"""Agent-driven MCP packaging pipeline.
+
+The modules in this package deliberately separate deterministic guardrails from
+semantic decisions: static analysis supplies evidence, while an Agent decides
+service boundaries and MCP capabilities.
+"""
+
+from micro_agent.packaging.analyzer import RepositoryAnalyzer, RepositoryIR
+from micro_agent.packaging.models import PackagingPlan, PlanValidationError
+
+__all__ = [
+    "PackagingPlan",
+    "PlanValidationError",
+    "RepositoryAnalyzer",
+    "RepositoryIR",
+]

--- a/micro_agent/packaging/analyzer.py
+++ b/micro_agent/packaging/analyzer.py
@@ -1,0 +1,396 @@
+"""Bounded repository inventory for the semantic packaging Agent.
+
+This module never decides which functions become MCP tools. It provides a
+complete, reproducible evidence layer so the Agent is not restricted to a
+single ``main.py`` or forced into one-tool-per-function heuristics.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+IGNORED_DIRS = {
+    ".git", ".hg", ".svn", ".idea", ".vscode", "__pycache__",
+    ".pytest_cache", ".mypy_cache", ".ruff_cache", ".venv", "venv",
+    "env", "node_modules", "dist", "build",
+}
+DOC_NAMES = {"readme", "readme.md", "readme.rst", "readme.txt"}
+ASSET_SUFFIXES = {
+    ".bin", ".ckpt", ".joblib", ".model", ".onnx", ".pkl", ".pickle",
+    ".pt", ".pth", ".safetensors", ".csv", ".json", ".yaml", ".yml",
+}
+
+
+@dataclass(frozen=True)
+class SymbolInfo:
+    qualifiedName: str
+    module: str
+    name: str
+    kind: str
+    file: str
+    line: int
+    signature: str
+    parameters: list[str]
+    requiredParameters: list[str]
+    docstring: str
+    decorators: list[str] = field(default_factory=list)
+    calls: list[str] = field(default_factory=list)
+    isGenerator: bool = False
+    failureReturns: list[str] = field(default_factory=list)
+    isPublic: bool = True
+
+
+@dataclass(frozen=True)
+class FileInfo:
+    path: str
+    size: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class RepositoryIR:
+    root: str
+    fingerprint: str
+    files: list[FileInfo]
+    symbols: list[SymbolInfo]
+    imports: dict[str, list[str]]
+    parseErrors: dict[str, str]
+    documentation: dict[str, str]
+    entrypointHints: list[str]
+    testFiles: list[str]
+    assetFiles: list[str]
+    truncated: bool = False
+
+    @property
+    def known_symbols(self) -> set[str]:
+        return {symbol.qualifiedName for symbol in self.symbols}
+
+    @property
+    def public_callable_symbols(self) -> set[str]:
+        return {
+            symbol.qualifiedName
+            for symbol in self.symbols
+            if symbol.isPublic
+            and symbol.kind in {"function", "async_function", "method", "async_method"}
+            and symbol.name != "main"
+            and not _is_lifecycle_or_operational_name(symbol.name)
+        }
+
+    def to_dict(self, *, include_root: bool = False) -> dict[str, Any]:
+        data = asdict(self)
+        if not include_root:
+            data.pop("root", None)
+        return data
+
+    def to_json(self, *, include_root: bool = False, indent: int | None = None) -> str:
+        return json.dumps(self.to_dict(include_root=include_root), ensure_ascii=False, indent=indent)
+
+
+class RepositoryAnalyzer:
+    def __init__(
+        self,
+        *,
+        max_files: int = 400,
+        max_python_bytes: int = 1_000_000,
+        max_total_python_bytes: int = 8_000_000,
+        max_doc_chars: int = 12_000,
+    ) -> None:
+        self.max_files = max_files
+        self.max_python_bytes = max_python_bytes
+        self.max_total_python_bytes = max_total_python_bytes
+        self.max_doc_chars = max_doc_chars
+
+    def analyze(self, root: str | Path) -> RepositoryIR:
+        root_path = Path(root).resolve()
+        if not root_path.is_dir():
+            raise ValueError(f"项目目录不存在: {root_path}")
+
+        candidates = [path for path in root_path.rglob("*") if self._include(path, root_path)]
+        candidates.sort(key=lambda path: path.relative_to(root_path).as_posix())
+        truncated = len(candidates) > self.max_files
+        candidates = candidates[: self.max_files]
+
+        files: list[FileInfo] = []
+        symbols: list[SymbolInfo] = []
+        imports: dict[str, list[str]] = {}
+        parse_errors: dict[str, str] = {}
+        docs: dict[str, str] = {}
+        entrypoints: list[str] = []
+        tests: list[str] = []
+        assets: list[str] = []
+        digest = hashlib.sha256()
+        total_python_bytes = 0
+
+        for path in candidates:
+            rel = path.relative_to(root_path).as_posix()
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            kind = _file_kind(path)
+            files.append(FileInfo(path=rel, size=stat.st_size, kind=kind))
+            digest.update(rel.encode("utf-8"))
+            digest.update(str(stat.st_size).encode("ascii"))
+
+            if _is_test_file(path, rel):
+                tests.append(rel)
+            if path.suffix.lower() in ASSET_SUFFIXES:
+                assets.append(rel)
+            if _looks_like_entrypoint(path, rel):
+                entrypoints.append(rel)
+
+            if path.name.lower() in DOC_NAMES:
+                try:
+                    content = path.read_text(encoding="utf-8", errors="replace")[: self.max_doc_chars]
+                    docs[rel] = content
+                    digest.update(content.encode("utf-8", errors="replace"))
+                except OSError:
+                    pass
+
+            if path.suffix.lower() != ".py":
+                continue
+            if stat.st_size > self.max_python_bytes:
+                parse_errors[rel] = f"文件超过单文件分析限制 ({self.max_python_bytes} bytes)"
+                continue
+            total_python_bytes += stat.st_size
+            if total_python_bytes > self.max_total_python_bytes:
+                parse_errors[rel] = f"仓库 Python 代码超过分析限制 ({self.max_total_python_bytes} bytes)"
+                truncated = True
+                continue
+            try:
+                source = path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                parse_errors[rel] = str(exc)
+                continue
+            digest.update(source.encode("utf-8", errors="replace"))
+            module = _module_name(rel)
+            try:
+                tree = ast.parse(source, filename=rel)
+            except SyntaxError as exc:
+                parse_errors[rel] = f"{exc.msg} (line {exc.lineno})"
+                continue
+            module_imports, module_symbols = _inspect_module(tree, module, rel)
+            imports[rel] = module_imports
+            symbols.extend(module_symbols)
+
+        if not symbols and not parse_errors:
+            parse_errors["<repository>"] = "未发现可分析的 Python 符号"
+
+        return RepositoryIR(
+            root=str(root_path),
+            fingerprint=digest.hexdigest(),
+            files=files,
+            symbols=symbols,
+            imports=imports,
+            parseErrors=parse_errors,
+            documentation=docs,
+            entrypointHints=sorted(set(entrypoints)),
+            testFiles=sorted(set(tests)),
+            assetFiles=sorted(set(assets)),
+            truncated=truncated,
+        )
+
+    @staticmethod
+    def _include(path: Path, root: Path) -> bool:
+        if not path.is_file() or path.is_symlink():
+            return False
+        rel_parts = path.relative_to(root).parts
+        if any(part in IGNORED_DIRS for part in rel_parts):
+            return False
+        if any(part.startswith(".") and part not in {".github"} for part in rel_parts):
+            return False
+        return True
+
+
+def _inspect_module(tree: ast.Module, module: str, rel: str) -> tuple[list[str], list[SymbolInfo]]:
+    imports: list[str] = []
+    symbols: list[SymbolInfo] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            base = "." * node.level + (node.module or "")
+            imports.extend(f"{base}.{alias.name}".strip(".") for alias in node.names)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            symbols.append(_symbol_from_function(node, module, rel, None))
+        elif isinstance(node, ast.ClassDef):
+            qualified = f"{module}.{node.name}"
+            symbols.append(
+                SymbolInfo(
+                    qualifiedName=qualified,
+                    module=module,
+                    name=node.name,
+                    kind="class",
+                    file=rel,
+                    line=node.lineno,
+                    signature=node.name,
+                    parameters=[],
+                    requiredParameters=[],
+                    docstring=(ast.get_docstring(node) or "")[:1000],
+                    decorators=[_safe_unparse(item) for item in node.decorator_list],
+                    calls=[],
+                    isGenerator=False,
+                    failureReturns=[],
+                    isPublic=not node.name.startswith("_"),
+                )
+            )
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    symbols.append(_symbol_from_function(child, module, rel, node.name))
+    return sorted(set(imports)), symbols
+
+
+def _symbol_from_function(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    module: str,
+    rel: str,
+    class_name: str | None,
+) -> SymbolInfo:
+    prefix = f"{module}.{class_name}" if class_name else module
+    qualified = f"{prefix}.{node.name}"
+    kind = "async_method" if class_name and isinstance(node, ast.AsyncFunctionDef) else (
+        "method" if class_name else ("async_function" if isinstance(node, ast.AsyncFunctionDef) else "function")
+    )
+    return SymbolInfo(
+        qualifiedName=qualified,
+        module=module,
+        name=node.name,
+        kind=kind,
+        file=rel,
+        line=node.lineno,
+        signature=_function_signature(node),
+        parameters=_function_parameter_names(node),
+        requiredParameters=_function_required_parameter_names(node),
+        docstring=(ast.get_docstring(node) or "")[:1000],
+        decorators=[_safe_unparse(item) for item in node.decorator_list],
+        calls=_function_calls(node),
+        isGenerator=any(isinstance(child, (ast.Yield, ast.YieldFrom)) for child in ast.walk(node)),
+        failureReturns=_failure_return_texts(node),
+        isPublic=not node.name.startswith("_"),
+    )
+
+
+def _function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    args = _safe_unparse(node.args)
+    returns = f" -> {_safe_unparse(node.returns)}" if node.returns else ""
+    return f"{node.name}({args}){returns}"
+
+
+def _function_parameter_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    names = [arg.arg for arg in [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]]
+    return [name for name in names if name not in {"self", "cls"}]
+
+
+def _function_required_parameter_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    positional = [*node.args.posonlyargs, *node.args.args]
+    defaulted_positional = {
+        arg.arg for arg in positional[len(positional) - len(node.args.defaults):]
+    } if node.args.defaults else set()
+    required = [
+        arg.arg
+        for arg in positional
+        if arg.arg not in {"self", "cls"} and arg.arg not in defaulted_positional
+    ]
+    required.extend(
+        arg.arg
+        for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults)
+        if default is None and arg.arg not in {"self", "cls"}
+    )
+    return required
+
+
+def _function_calls(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    calls: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        name = _call_name(child.func)
+        if name:
+            calls.add(name)
+    return sorted(calls)
+
+
+def _failure_return_texts(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    result: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.ExceptHandler):
+            continue
+        for nested in ast.walk(child):
+            if not isinstance(nested, ast.Return) or nested.value is None:
+                continue
+            if isinstance(nested.value, ast.Constant) and isinstance(nested.value.value, str):
+                result.add(nested.value.value[:200])
+            elif isinstance(nested.value, ast.JoinedStr):
+                static = "".join(
+                    part.value
+                    for part in nested.value.values
+                    if isinstance(part, ast.Constant) and isinstance(part.value, str)
+                ).strip()
+                if static:
+                    result.add(static[:200])
+    return sorted(result)
+
+
+def _call_name(node: ast.expr) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _call_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    return ""
+
+
+def _safe_unparse(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return ""
+
+
+def _module_name(rel: str) -> str:
+    no_suffix = rel[:-3] if rel.endswith(".py") else rel
+    parts = list(Path(no_suffix).parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) or "__init__"
+
+
+def _file_kind(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".py":
+        return "python"
+    if path.name.lower() in DOC_NAMES or suffix in {".md", ".rst", ".txt"}:
+        return "documentation"
+    if suffix in ASSET_SUFFIXES:
+        return "asset"
+    if path.name in {"requirements.txt", "pyproject.toml", "setup.py", "setup.cfg", "Pipfile"}:
+        return "dependency"
+    return "other"
+
+
+def _is_test_file(path: Path, rel: str) -> bool:
+    return path.name.startswith("test_") or path.name.endswith("_test.py") or "tests" in Path(rel).parts
+
+
+def _looks_like_entrypoint(path: Path, rel: str) -> bool:
+    if path.name in {"main.py", "app.py", "server.py", "run.py", "start.py", "__main__.py"}:
+        return True
+    return path.suffix.lower() == ".py" and any(part in {"cli", "scripts", "examples"} for part in Path(rel).parts)
+
+
+def _is_lifecycle_or_operational_name(name: str) -> bool:
+    normalized = name.lower()
+    return normalized.startswith(("load_", "init_", "initialize_")) or normalized in {
+        "health", "health_check", "readiness", "liveness", "status", "service_status",
+        "get_model_info", "model_info", "get_model_metadata", "model_metadata",
+        "get_metadata", "metadata",
+    }

--- a/micro_agent/packaging/models.py
+++ b/micro_agent/packaging/models.py
@@ -1,0 +1,605 @@
+"""Validated contract shared by the planning Agent, builder Agent and UI graph."""
+
+from __future__ import annotations
+
+import copy
+import base64
+import binascii
+import io
+import json
+import keyword
+import re
+import zipfile
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = "ioeb.agentic-mcp-plan/v1"
+_SNAKE_CASE = re.compile(r"^[a-z][a-z0-9_]{1,63}$")
+
+
+class PlanValidationError(ValueError):
+    """Raised when an Agent plan cannot be trusted by downstream stages."""
+
+    def __init__(self, errors: Iterable[str]):
+        self.errors = list(errors)
+        super().__init__("; ".join(self.errors))
+
+
+@dataclass(frozen=True)
+class PackagingPlan:
+    """A validated, immutable-by-convention packaging plan."""
+
+    data: dict[str, Any]
+
+    @classmethod
+    def validate(
+        cls,
+        raw: dict[str, Any],
+        *,
+        known_symbols: set[str] | None = None,
+        known_files: set[str] | None = None,
+        symbol_required_parameters: dict[str, list[str]] | None = None,
+        symbol_calls: dict[str, list[str]] | None = None,
+        symbol_is_generator: dict[str, bool] | None = None,
+        candidate_symbols: set[str] | None = None,
+    ) -> "PackagingPlan":
+        if not isinstance(raw, dict):
+            raise PlanValidationError(["plan 必须是 JSON object"])
+
+        data = copy.deepcopy(raw)
+        errors: list[str] = []
+        if data.get("schemaVersion") != SCHEMA_VERSION:
+            errors.append(f"schemaVersion 必须是 {SCHEMA_VERSION}")
+
+        decision = data.get("decision")
+        if decision not in {"package", "reject"}:
+            errors.append("decision 必须是 package 或 reject")
+
+        summary = data.get("analysisSummary")
+        if not isinstance(summary, str) or len(summary.strip()) < 10:
+            errors.append("analysisSummary 必须给出不少于 10 个字符的分析结论")
+
+        if decision == "reject":
+            reasons = data.get("rejectionReasons")
+            if not isinstance(reasons, list) or not any(
+                isinstance(item, str) and item.strip() for item in reasons
+            ):
+                errors.append("拒绝封装时必须提供 rejectionReasons")
+            if data.get("services") not in (None, []):
+                errors.append("拒绝封装时 services 必须为空")
+            if errors:
+                raise PlanValidationError(errors)
+            data.setdefault("services", [])
+            data.setdefault("excludedSymbols", [])
+            data.setdefault("assumptions", [])
+            data.setdefault("riskNotes", [])
+            return cls(data)
+
+        services = data.get("services")
+        if not isinstance(services, list) or not 1 <= len(services) <= 5:
+            errors.append("services 必须包含 1 到 5 个逻辑服务边界")
+            services = []
+
+        seen_service_ids: set[str] = set()
+        seen_tool_names: set[str] = set()
+        tools: list[dict[str, Any]] = []
+        for service_index, service in enumerate(services):
+            prefix = f"services[{service_index}]"
+            if not isinstance(service, dict):
+                errors.append(f"{prefix} 必须是 object")
+                continue
+            service_id = service.get("id")
+            if not isinstance(service_id, str) or not _SNAKE_CASE.match(service_id):
+                errors.append(f"{prefix}.id 必须是 snake_case")
+            elif service_id in seen_service_ids:
+                errors.append(f"逻辑服务 id 重复: {service_id}")
+            else:
+                seen_service_ids.add(service_id)
+
+            for field in ("name", "description", "rationale"):
+                if not isinstance(service.get(field), str) or not service[field].strip():
+                    errors.append(f"{prefix}.{field} 不能为空")
+
+            service_tools = service.get("tools")
+            if not isinstance(service_tools, list) or not service_tools:
+                errors.append(f"{prefix}.tools 至少包含一个工具")
+                continue
+            tools.extend(item for item in service_tools if isinstance(item, dict))
+            if len(service_tools) != len([item for item in service_tools if isinstance(item, dict)]):
+                errors.append(f"{prefix}.tools 中存在非 object 条目")
+
+        if len(tools) > 20:
+            errors.append("单个 MCP Server 最多规划 20 个工具")
+
+        for tool_index, tool in enumerate(tools):
+            prefix = f"tool[{tool_index}]"
+            name = tool.get("name")
+            if not isinstance(name, str) or not _SNAKE_CASE.match(name):
+                errors.append(f"{prefix}.name 必须是 snake_case")
+            elif name in seen_tool_names:
+                errors.append(f"工具名称重复: {name}")
+            else:
+                seen_tool_names.add(name)
+                if name in {
+                    "health", "health_check", "readiness", "liveness", "status",
+                    "service_status", "get_model_info", "model_info", "get_model_metadata",
+                    "model_metadata", "get_metadata", "metadata",
+                }:
+                    errors.append(
+                        f"{prefix}.name={name} 是运维/模型元数据接口，不是用户算法能力；应写入 excludedSymbols"
+                    )
+
+            if not isinstance(tool.get("description"), str) or len(tool["description"].strip()) < 8:
+                errors.append(f"{prefix}.description 描述不足")
+
+            symbols = tool.get("sourceSymbols")
+            if not isinstance(symbols, list) or not symbols or not all(
+                isinstance(symbol, str) and symbol for symbol in symbols
+            ):
+                errors.append(f"{prefix}.sourceSymbols 至少引用一个源码符号")
+            elif known_symbols is not None:
+                unknown = sorted(set(symbols) - known_symbols)
+                if unknown:
+                    errors.append(f"{prefix}.sourceSymbols 包含未知符号: {', '.join(unknown)}")
+
+            for schema_field in ("inputSchema", "outputSchema"):
+                schema = tool.get(schema_field)
+                if not isinstance(schema, dict) or not isinstance(schema.get("type"), str):
+                    errors.append(f"{prefix}.{schema_field} 必须是带 type 的 JSON Schema")
+                elif _server_path_fields(schema):
+                    errors.append(
+                        f"{prefix}.{schema_field} 暴露了容器文件系统字段 "
+                        f"{sorted(_server_path_fields(schema))}；远程 MCP 调用者无法访问服务端路径，"
+                        "必须在一个端到端工具内完成中间文件处理"
+                    )
+            input_schema = tool.get("inputSchema")
+            if isinstance(input_schema, dict) and input_schema.get("type") != "object":
+                errors.append(f"{prefix}.inputSchema.type 必须是 object")
+            if isinstance(input_schema, dict):
+                properties = input_schema.get("properties", {})
+                required = input_schema.get("required", [])
+                if not isinstance(properties, dict):
+                    errors.append(f"{prefix}.inputSchema.properties 必须是 object")
+                    properties = {}
+                invalid_params = [
+                    name
+                    for name in properties
+                    if not isinstance(name, str) or not name.isidentifier() or keyword.iskeyword(name)
+                ]
+                if invalid_params:
+                    errors.append(f"{prefix}.inputSchema 包含非法参数名: {invalid_params}")
+                if not isinstance(required, list) or not all(isinstance(name, str) for name in required):
+                    errors.append(f"{prefix}.inputSchema.required 必须是参数名数组")
+                elif not set(required).issubset(properties):
+                    errors.append(f"{prefix}.inputSchema.required 引用了未定义参数")
+                if (
+                    symbol_required_parameters is not None
+                    and isinstance(symbols, list)
+                    and len(symbols) == 1
+                    and symbols[0] in symbol_required_parameters
+                    and (
+                        len(properties) < len(symbol_required_parameters[symbols[0]])
+                        or not isinstance(required, list)
+                        or len(required) < len(symbol_required_parameters[symbols[0]])
+                    )
+                ):
+                    errors.append(
+                        f"{prefix}.inputSchema 参数不足以调用 {symbols[0]}："
+                        f"源码必填参数为 {symbol_required_parameters[symbols[0]]}；"
+                        "若参数由适配层派生，必须把足够的用户输入加入 Schema 并标为 required"
+                    )
+            output_schema = tool.get("outputSchema")
+            if (
+                symbol_is_generator is not None
+                and isinstance(symbols, list)
+                and len(symbols) == 1
+                and symbol_is_generator.get(symbols[0])
+                and isinstance(output_schema, dict)
+                and output_schema.get("type") != "array"
+            ):
+                errors.append(
+                    f"{prefix}.outputSchema 必须是 array：源码 {symbols[0]} 使用 yield 返回多项结果"
+                )
+            if isinstance(output_schema, dict) and output_schema.get("type") == "object":
+                output_properties = output_schema.get("properties", {})
+                output_required = output_schema.get("required", [])
+                if not isinstance(output_properties, dict):
+                    errors.append(f"{prefix}.outputSchema.properties 必须是 object")
+                elif output_properties and (
+                    not isinstance(output_required, list)
+                    or not output_required
+                    or not all(isinstance(name, str) for name in output_required)
+                ):
+                    errors.append(
+                        f"{prefix}.outputSchema 声明了字段时必须用 required 明确至少一个稳定返回字段"
+                    )
+                elif isinstance(output_required, list) and not set(output_required).issubset(output_properties):
+                    errors.append(f"{prefix}.outputSchema.required 引用了未定义字段")
+
+            strategy = tool.get("adapterStrategy")
+            if not isinstance(strategy, str) or len(strategy.strip()) < 8:
+                errors.append(f"{prefix}.adapterStrategy 必须说明适配或重构策略")
+
+            depends_on = tool.get("dependsOn", [])
+            if not isinstance(depends_on, list) or not all(isinstance(v, str) for v in depends_on):
+                errors.append(f"{prefix}.dependsOn 必须是工具名数组")
+
+            smoke = tool.get("smokeTest")
+            if not isinstance(smoke, dict) or not isinstance(smoke.get("enabled"), bool):
+                errors.append(f"{prefix}.smokeTest 必须声明 enabled")
+            elif smoke.get("enabled") and not isinstance(smoke.get("input"), dict):
+                errors.append(f"{prefix}.smokeTest.input 必须是 object")
+            elif not smoke.get("enabled") and not isinstance(smoke.get("rationale"), str):
+                errors.append(f"{prefix}.smokeTest.enabled=false 时必须说明 rationale")
+            elif smoke.get("enabled"):
+                smoke_errors = _validate_smoke_input(smoke.get("input", {}), input_schema or {})
+                errors.extend(f"{prefix}.smokeTest: {error}" for error in smoke_errors)
+                smoke_evidence = smoke.get("evidence")
+                if not isinstance(smoke_evidence, list) or not smoke_evidence or not all(
+                    isinstance(item, str) and item.strip() for item in smoke_evidence
+                ):
+                    errors.append(
+                        f"{prefix}.smokeTest.evidence 必须指出样例值或约束来自仓库中的哪个文件"
+                    )
+                elif known_files is not None and not any(
+                    any(file_path in item for file_path in known_files)
+                    for item in smoke_evidence
+                ):
+                    errors.append(
+                        f"{prefix}.smokeTest.evidence 未引用仓库中的真实文件；无可追溯输入时应 enabled=false"
+                    )
+
+            evidence = tool.get("evidence")
+            if not isinstance(evidence, list) or not evidence or not all(
+                isinstance(item, str) and item.strip() for item in evidence
+            ):
+                errors.append(f"{prefix}.evidence 至少包含一条源码或文档证据")
+
+        for tool in tools:
+            for dependency in tool.get("dependsOn", []):
+                if dependency not in seen_tool_names:
+                    errors.append(f"工具 {tool.get('name')} 依赖不存在的工具 {dependency}")
+                if dependency == tool.get("name"):
+                    errors.append(f"工具 {tool.get('name')} 不能依赖自身")
+
+        semantic_surfaces: dict[str, str] = {}
+        for tool in tools:
+            surface = json.dumps(
+                {
+                    "sourceSymbols": sorted(tool.get("sourceSymbols", [])),
+                    "inputSchema": tool.get("inputSchema"),
+                    "outputSchema": tool.get("outputSchema"),
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+            )
+            previous = semantic_surfaces.get(surface)
+            if previous:
+                errors.append(
+                    f"工具 {previous} 与 {tool.get('name')} 暴露了完全相同的源码和输入输出，"
+                    "必须合并为一个端到端用户能力"
+                )
+            else:
+                semantic_surfaces[surface] = str(tool.get("name"))
+
+        if errors:
+            raise PlanValidationError(errors)
+
+        data.setdefault("rejectionReasons", [])
+        data.setdefault("excludedSymbols", [])
+        data.setdefault("assumptions", [])
+        data.setdefault("riskNotes", [])
+        for field in ("rejectionReasons", "assumptions", "riskNotes"):
+            if not isinstance(data[field], list) or not all(isinstance(item, str) for item in data[field]):
+                errors.append(f"{field} 必须是字符串数组")
+        excluded = data["excludedSymbols"]
+        if not isinstance(excluded, list):
+            errors.append("excludedSymbols 必须是数组")
+        elif not all(
+            isinstance(item, dict)
+            and isinstance(item.get("symbol"), str)
+            and isinstance(item.get("reason"), str)
+            for item in excluded
+        ):
+            errors.append("excludedSymbols 每项必须包含 symbol 和 reason")
+        elif candidate_symbols is not None:
+            included_symbols = {
+                symbol
+                for tool in tools
+                for symbol in tool.get("sourceSymbols", [])
+            }
+            excluded_symbols = {item["symbol"] for item in excluded}
+            unknown_excluded = sorted(
+                excluded_symbols - (known_symbols if known_symbols is not None else candidate_symbols)
+            )
+            if unknown_excluded:
+                errors.append(f"excludedSymbols 包含仓库中不存在的符号: {unknown_excluded}")
+            unclassified = sorted(candidate_symbols - included_symbols - excluded_symbols)
+            if unclassified:
+                errors.append(
+                    "以下公开可调用符号尚未说明暴露或排除理由: "
+                    + ", ".join(unclassified)
+                )
+            if symbol_calls is not None:
+                composed = _reachable_symbols(included_symbols, symbol_calls)
+                unjustified = sorted(
+                    symbol
+                    for symbol in excluded_symbols & candidate_symbols
+                    if _looks_like_user_capability(symbol) and symbol not in composed
+                )
+                if unjustified:
+                    errors.append(
+                        "以下独立预测/计算能力不能仅以‘内部/非核心/未来支持’为由排除；"
+                        "应规划为 Tool，或由 sourceSymbols 中的端到端能力通过调用图真实组合: "
+                        + ", ".join(unjustified)
+                    )
+        if errors:
+            raise PlanValidationError(errors)
+        return cls(data)
+
+    @property
+    def decision(self) -> str:
+        return str(self.data["decision"])
+
+    @property
+    def tools(self) -> list[dict[str, Any]]:
+        return [
+            tool
+            for service in self.data.get("services", [])
+            for tool in service.get("tools", [])
+        ]
+
+    @property
+    def tool_names(self) -> list[str]:
+        return [str(tool["name"]) for tool in self.tools]
+
+    def to_dict(self) -> dict[str, Any]:
+        return copy.deepcopy(self.data)
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.data, ensure_ascii=False, indent=indent)
+
+    def to_frontend_graph(self) -> dict[str, Any]:
+        """Convert semantic tools to the legacy graph contract without UI changes."""
+        nodes: list[dict[str, Any]] = []
+        node_ids: dict[str, str] = {}
+        for index, tool in enumerate(self.tools):
+            node_id = str(9001 + index)
+            node_ids[tool["name"]] = node_id
+            properties = tool["inputSchema"].get("properties", {})
+            required = set(tool["inputSchema"].get("required", []))
+            inputs = []
+            if isinstance(properties, dict):
+                for name, schema in properties.items():
+                    type_name = schema.get("type", "any") if isinstance(schema, dict) else "any"
+                    suffix = "" if name in required else "?"
+                    inputs.append(f"{name}{suffix}: {type_name}")
+            nodes.append(
+                {
+                    "id": node_id,
+                    "x": (index % 4) * 180,
+                    "y": (index // 4) * 140,
+                    "label": tool["name"],
+                    "size": 50,
+                    "input": ", ".join(inputs) or "None",
+                    "output": _schema_label(tool["outputSchema"]),
+                    "description": tool["description"],
+                    "environment": "Agent 语义规划",
+                    "process": tool["adapterStrategy"],
+                    "apiType": "mcp",
+                    "methodType": "tool",
+                    "inputType": "json",
+                    "outputType": "json",
+                    "mcpType": "tool",
+                    "serviceId": _service_id_for_tool(self.data, tool["name"]),
+                    "sourceSymbols": tool["sourceSymbols"],
+                }
+            )
+
+        edges: list[dict[str, str]] = []
+        seen_edges: set[tuple[str, str]] = set()
+        for tool in self.tools:
+            target = node_ids[tool["name"]]
+            for dependency in tool.get("dependsOn", []):
+                source = node_ids.get(dependency)
+                if source and (source, target) not in seen_edges:
+                    edges.append({"sourceID": source, "targetID": target})
+                    seen_edges.add((source, target))
+        return {
+            "nodes": nodes,
+            "edges": edges,
+            "meta": {
+                "schemaVersion": SCHEMA_VERSION,
+                "engine": "agentic",
+                "serviceCount": len(self.data.get("services", [])),
+                "toolCount": len(nodes),
+                "analysisSummary": self.data.get("analysisSummary", ""),
+            },
+        }
+
+
+def _schema_label(schema: dict[str, Any]) -> str:
+    type_name = str(schema.get("type", "any"))
+    if type_name == "object" and isinstance(schema.get("properties"), dict):
+        keys = ", ".join(schema["properties"].keys())
+        return f"object({keys})" if keys else "object"
+    if type_name == "array":
+        items = schema.get("items", {})
+        return f"array[{items.get('type', 'any')}]" if isinstance(items, dict) else "array"
+    return type_name
+
+
+def _service_id_for_tool(data: dict[str, Any], tool_name: str) -> str:
+    for service in data.get("services", []):
+        if any(tool.get("name") == tool_name for tool in service.get("tools", [])):
+            return str(service.get("id", ""))
+    return ""
+
+
+_SERVER_PATH_NAMES = {
+    "path", "dir", "directory", "save_dir", "data_path", "dataset_path",
+    "file_path", "model_path", "output_path", "input_path", "temp_dir",
+}
+
+
+def _server_path_fields(schema: dict[str, Any]) -> set[str]:
+    found: set[str] = set()
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return found
+    for name, child in properties.items():
+        normalized = str(name).lower()
+        if normalized in _SERVER_PATH_NAMES or normalized.endswith(("_path", "_dir", "_directory")):
+            found.add(str(name))
+        if isinstance(child, dict):
+            found.update(_server_path_fields(child))
+            items = child.get("items")
+            if isinstance(items, dict):
+                found.update(_server_path_fields(items))
+    return found
+
+
+def _validate_smoke_input(smoke_input: dict[str, Any], input_schema: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    properties = input_schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return errors
+    unknown = sorted(set(smoke_input) - set(properties))
+    if unknown:
+        errors.append(f"input 包含 schema 外字段: {unknown}")
+    missing = sorted(set(input_schema.get("required", [])) - set(smoke_input))
+    if missing:
+        errors.append(f"input 缺少必填字段: {missing}")
+    for name, value in smoke_input.items():
+        child = properties.get(name)
+        if not isinstance(child, dict) or not isinstance(value, str):
+            continue
+        description = str(child.get("description", "")).lower()
+        looks_base64 = "base64" in name.lower() or "base64" in description or child.get("contentEncoding") == "base64"
+        if not looks_base64:
+            continue
+        try:
+            decoded = base64.b64decode(value, validate=True)
+        except (ValueError, binascii.Error):
+            errors.append(f"字段 {name} 不是合法 Base64")
+            continue
+        if "zip" in name.lower() or "zip" in description:
+            if not zipfile.is_zipfile(io.BytesIO(decoded)):
+                errors.append(f"字段 {name} 不是完整有效的 ZIP；没有真实 fixture 时应设置 enabled=false")
+    return errors
+
+
+def _looks_like_user_capability(symbol: str) -> bool:
+    name = symbol.rsplit(".", 1)[-1].lower()
+    return bool(
+        re.search(
+            r"(?:^|_)(?:predict|infer|evaluate|calculate|score|dose|simulate|forecast|classify|detect|recommend)(?:_|$)",
+            name,
+        )
+    )
+
+
+def _reachable_symbols(
+    roots: set[str],
+    symbol_calls: dict[str, list[str]],
+) -> set[str]:
+    by_tail: dict[str, set[str]] = {}
+    for symbol in symbol_calls:
+        by_tail.setdefault(symbol.rsplit(".", 1)[-1], set()).add(symbol)
+    edges: dict[str, set[str]] = {}
+    for symbol, calls in symbol_calls.items():
+        targets: set[str] = set()
+        for call in calls:
+            targets.update(by_tail.get(call.rsplit(".", 1)[-1], set()))
+        edges[symbol] = targets
+    visited = set(roots)
+    pending = list(roots)
+    while pending:
+        current = pending.pop()
+        for target in edges.get(current, set()):
+            if target not in visited:
+                visited.add(target)
+                pending.append(target)
+    return visited - roots
+
+
+PLAN_JSON_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "ioeb.agentic-mcp-plan/v1 packaging plan",
+    "properties": {
+        "schemaVersion": {"type": "string", "const": SCHEMA_VERSION},
+        "decision": {"type": "string", "enum": ["package", "reject"]},
+        "analysisSummary": {"type": "string"},
+        "rejectionReasons": {"type": "array", "items": {"type": "string"}},
+        "services": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "description": {"type": "string"},
+                    "rationale": {"type": "string"},
+                    "tools": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "description": {"type": "string"},
+                                "sourceSymbols": {"type": "array", "items": {"type": "string"}},
+                                "inputSchema": {"type": "object"},
+                                "outputSchema": {"type": "object"},
+                                "adapterStrategy": {"type": "string"},
+                                "dependsOn": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": "仅填写同一规划中其他 MCP Tool 的 name；不填写服务 id、源码模块、模型或文件名，无工具依赖时为 []",
+                                },
+                                "smokeTest": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {"type": "boolean"},
+                                        "input": {"type": "object"},
+                                        "rationale": {
+                                            "type": "string",
+                                            "description": "enabled=false 时说明仓库缺少哪种真实 fixture",
+                                        },
+                                        "evidence": {
+                                            "type": "array",
+                                            "items": {"type": "string"},
+                                            "description": "enabled=true 时引用真实样例文件，或明确输入约束所在源码文件与行号",
+                                        },
+                                    },
+                                    "required": ["enabled"],
+                                },
+                                "evidence": {"type": "array", "items": {"type": "string"}},
+                            },
+                            "required": [
+                                "name", "description", "sourceSymbols", "inputSchema",
+                                "outputSchema", "adapterStrategy", "dependsOn", "smokeTest", "evidence",
+                            ],
+                        },
+                    },
+                },
+                "required": ["id", "name", "description", "rationale", "tools"],
+            },
+        },
+        "excludedSymbols": {
+            "type": "array",
+            "description": "所有未被 sourceSymbols 使用的公开函数/方法及其不暴露理由",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string"},
+                    "reason": {"type": "string"},
+                },
+                "required": ["symbol", "reason"],
+            },
+        },
+        "assumptions": {"type": "array", "items": {"type": "string"}},
+        "riskNotes": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["schemaVersion", "decision", "analysisSummary", "services"],
+}

--- a/micro_agent/packaging/runtime_guardrails.py
+++ b/micro_agent/packaging/runtime_guardrails.py
@@ -1,0 +1,57 @@
+"""Runtime helpers copied into generated artifacts for untrusted binary inputs."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import io
+import stat
+import zipfile
+from pathlib import PurePosixPath
+
+
+def decode_safe_zip(
+    encoded: str,
+    *,
+    max_entries: int = 2_000,
+    max_compressed_bytes: int = 100_000_000,
+    max_uncompressed_bytes: int = 1_000_000_000,
+    max_compression_ratio: float = 200.0,
+) -> io.BytesIO:
+    """Decode and validate a ZIP before legacy algorithm code extracts it."""
+    try:
+        payload = base64.b64decode(encoded, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("input is not valid Base64") from exc
+    if len(payload) > max_compressed_bytes:
+        raise ValueError("compressed ZIP exceeds size limit")
+
+    stream = io.BytesIO(payload)
+    try:
+        with zipfile.ZipFile(stream) as archive:
+            members = archive.infolist()
+            if len(members) > max_entries:
+                raise ValueError("ZIP contains too many entries")
+            total = 0
+            for member in members:
+                _validate_member_path(member.filename)
+                mode = member.external_attr >> 16
+                if stat.S_ISLNK(mode):
+                    raise ValueError("ZIP symbolic links are not allowed")
+                total += member.file_size
+                if total > max_uncompressed_bytes:
+                    raise ValueError("uncompressed ZIP exceeds size limit")
+                compressed = max(member.compress_size, 1)
+                if member.file_size / compressed > max_compression_ratio:
+                    raise ValueError("ZIP compression ratio exceeds safety limit")
+    except zipfile.BadZipFile as exc:
+        raise ValueError("input is not a valid ZIP archive") from exc
+    stream.seek(0)
+    return stream
+
+
+def _validate_member_path(name: str) -> None:
+    normalized = name.replace("\\", "/")
+    path = PurePosixPath(normalized)
+    if path.is_absolute() or ".." in path.parts or (path.parts and ":" in path.parts[0]):
+        raise ValueError(f"unsafe ZIP member path: {name}")

--- a/micro_agent/packaging/scaffold.py
+++ b/micro_agent/packaging/scaffold.py
@@ -1,0 +1,239 @@
+"""Deterministic, non-semantic artifact scaffold for the builder Agent."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import keyword
+from pathlib import Path
+from typing import Any
+
+from micro_agent.packaging.models import PackagingPlan
+
+
+IGNORED_NAMES = {
+    ".git", ".hg", ".svn", ".idea", ".vscode", "__pycache__",
+    ".pytest_cache", ".mypy_cache", ".ruff_cache", ".venv", "venv",
+    "env", "node_modules", "dist", "build", ".env",
+}
+IGNORED_SUFFIXES = {".key", ".pem", ".p12", ".pfx", ".pyc"}
+
+
+def prepare_artifact(project_dir: str | Path, artifact_dir: str | Path, plan: PackagingPlan) -> Path:
+    """Create safe deployment boilerplate and copy submitted code verbatim.
+
+    Service semantics, adapters and MCP tool implementations are intentionally
+    absent here; the builder Agent must create them from the validated plan.
+    """
+    source_root = Path(project_dir).resolve()
+    output_root = Path(artifact_dir).resolve()
+    if output_root.exists():
+        shutil.rmtree(output_root)
+    output_root.mkdir(parents=True)
+
+    algorithm_root = output_root / "algorithm"
+    algorithm_root.mkdir()
+    _copy_project(source_root, algorithm_root)
+    (algorithm_root / "__init__.py").touch(exist_ok=True)
+
+    requirements = _read_requirements(source_root)
+    requirements = _merge_requirements(
+        requirements,
+        ["mcp>=1.28.0,<2", "starlette>=0.37.0,<2", "uvicorn[standard]>=0.30.0,<1"],
+    )
+    (output_root / "requirements.txt").write_text("\n".join(requirements) + "\n", encoding="utf-8")
+
+    service_id = plan.data["services"][0]["id"]
+    compose_name = re.sub(r"[^a-z0-9_-]", "-", service_id.lower()).strip("-") or "mcp-service"
+    (output_root / "Dockerfile").write_text(
+        "FROM python:3.11-slim\n"
+        "ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1\n"
+        "WORKDIR /app\n"
+        "COPY requirements.txt /app/requirements.txt\n"
+        "RUN pip install --no-cache-dir -r /app/requirements.txt\n"
+        "COPY . /app\n"
+        "EXPOSE 8000\n"
+        "CMD [\"python\", \"server.py\"]\n",
+        encoding="utf-8",
+    )
+    (output_root / "docker-compose.yml").write_text(
+        "services:\n"
+        f"  {compose_name}:\n"
+        "    build: .\n"
+        "    restart: unless-stopped\n"
+        "    ports:\n"
+        "      - \"8000\"\n"
+        "    environment:\n"
+        "      - PYTHONUNBUFFERED=1\n",
+        encoding="utf-8",
+    )
+    (output_root / "packaging_plan.json").write_text(plan.to_json() + "\n", encoding="utf-8")
+    (output_root / "ioeb-service.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "ioeb.mcp-service/v1",
+                "engine": "agentic",
+                "transport": "sse",
+                "endpoint": "/sse",
+                "messagesEndpoint": "/messages/",
+                "port": 8000,
+                "services": [
+                    {
+                        "id": service["id"],
+                        "name": service["name"],
+                        "description": service["description"],
+                        "tools": [tool["name"] for tool in service["tools"]],
+                    }
+                    for service in plan.data["services"]
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_root / "algorithm_loader.py").write_text(
+        '"""Stable import boundary for the submitted algorithm repository."""\n'
+        "\n"
+        "from pathlib import Path\n"
+        "import sys\n"
+        "\n"
+        "ALGORITHM_DIR = Path(__file__).resolve().parent / \"algorithm\"\n"
+        "if str(ALGORITHM_DIR) not in sys.path:\n"
+        "    sys.path.insert(0, str(ALGORITHM_DIR))\n",
+        encoding="utf-8",
+    )
+    shutil.copy2(Path(__file__).with_name("runtime_guardrails.py"), output_root / "runtime_guardrails.py")
+    (output_root / "server.py").write_text(_render_server(plan), encoding="utf-8")
+    return output_root
+
+
+def _copy_project(source_root: Path, algorithm_root: Path) -> None:
+    for source in sorted(source_root.rglob("*")):
+        rel = source.relative_to(source_root)
+        if any(part in IGNORED_NAMES for part in rel.parts):
+            continue
+        if source.is_symlink() or not source.is_file():
+            continue
+        if source.suffix.lower() in IGNORED_SUFFIXES:
+            continue
+        target = algorithm_root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def _read_requirements(root: Path) -> list[str]:
+    path = root / "requirements.txt"
+    if not path.is_file():
+        return []
+    return [line.rstrip() for line in path.read_text(encoding="utf-8", errors="replace").splitlines()]
+
+
+def _merge_requirements(original: list[str], required: list[str]) -> list[str]:
+    forced_names = {"mcp", "starlette", "uvicorn"}
+    result = [
+        line
+        for line in original
+        if line.strip() and _requirement_name(line) not in forced_names
+    ]
+    package_names = {
+        re.split(r"[<>=!~\[\s]", line.strip(), maxsplit=1)[0].lower().replace("_", "-")
+        for line in result
+        if line.strip() and not line.lstrip().startswith(("#", "-"))
+    }
+    for requirement in required:
+        name = re.split(r"[<>=!~\[]", requirement, maxsplit=1)[0].lower().replace("_", "-")
+        if name not in package_names:
+            result.append(requirement)
+    return result
+
+
+def _requirement_name(line: str) -> str:
+    if not line.strip() or line.lstrip().startswith(("#", "-")):
+        return ""
+    return re.split(r"[<>=!~\[\s]", line.strip(), maxsplit=1)[0].lower().replace("_", "-")
+
+
+def _render_server(plan: PackagingPlan) -> str:
+    """Render protocol boilerplate from the Agent-reviewed capability contract.
+
+    The renderer makes no service-design decisions. Keeping transport code out
+    of the LLM edit surface prevents syntactically valid but unusable MCP
+    variants such as ``from mcp import mcp``.
+    """
+    service_name = plan.data["services"][0]["name"]
+    lines = [
+        '"""Generated MCP protocol boundary; semantic adapters live in adapters.py."""',
+        "",
+        "from typing import Any",
+        "",
+        "import uvicorn",
+        "from mcp.server.fastmcp import FastMCP",
+        "",
+        "import adapters",
+        "",
+        f"mcp = FastMCP({service_name!r}, host=\"0.0.0.0\", port=8000, sse_path=\"/sse\", message_path=\"/messages/\")",
+        "",
+    ]
+    for tool in plan.tools:
+        properties = tool["inputSchema"].get("properties", {})
+        required = set(tool["inputSchema"].get("required", []))
+        if not isinstance(properties, dict):
+            properties = {}
+        ordered_names = [name for name in properties if name in required] + [
+            name for name in properties if name not in required
+        ]
+        params: list[str] = []
+        for name in ordered_names:
+            if not isinstance(name, str) or not name.isidentifier() or keyword.iskeyword(name):
+                raise ValueError(f"工具 {tool['name']} 包含非法 Python 参数名: {name}")
+            annotation = _python_type(properties[name])
+            default = "" if name in required else " = None"
+            if name not in required:
+                annotation = f"{annotation} | None"
+            params.append(f"{name}: {annotation}{default}")
+        return_type = _python_type(tool["outputSchema"])
+        lines.extend(
+            [
+                "@mcp.tool()",
+                f"def {tool['name']}({', '.join(params)}) -> {return_type}:",
+                f"    {json.dumps(tool['description'], ensure_ascii=False)}",
+                f"    return adapters.{tool['name']}({', '.join(f'{name}={name}' for name in ordered_names)})",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "starlette_app = mcp.sse_app()",
+            "",
+            'if __name__ == "__main__":',
+            '    uvicorn.run(starlette_app, host="0.0.0.0", port=8000)',
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _python_type(schema: Any) -> str:
+    if not isinstance(schema, dict):
+        return "Any"
+    type_name = schema.get("type")
+    if isinstance(type_name, list):
+        non_null = [item for item in type_name if item != "null"]
+        inner = _python_type({**schema, "type": non_null[0]}) if len(non_null) == 1 else "Any"
+        return f"{inner} | None" if "null" in type_name else inner
+    if type_name == "string":
+        return "str"
+    if type_name == "integer":
+        return "int"
+    if type_name == "number":
+        return "float"
+    if type_name == "boolean":
+        return "bool"
+    if type_name == "array":
+        return f"list[{_python_type(schema.get('items', {}))}]"
+    if type_name == "object":
+        return "dict[str, Any]"
+    return "Any"

--- a/micro_agent/packaging/tools.py
+++ b/micro_agent/packaging/tools.py
@@ -1,0 +1,318 @@
+"""Path-contained tools exposed to the packaging Agents instead of host Bash."""
+
+from __future__ import annotations
+
+import ast
+import io
+import json
+import re
+import tokenize
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from micro_agent.packaging.analyzer import RepositoryIR
+from micro_agent.packaging.models import PLAN_JSON_SCHEMA, PackagingPlan, PlanValidationError
+from micro_agent.packaging.verifier import ArtifactVerifier
+from micro_agent.tool.base import Tool, ToolResult
+
+
+def _contained_path(root: Path, relative: str) -> Path:
+    if not relative or "\x00" in relative:
+        raise ValueError("文件路径不能为空")
+    candidate = (root / relative).resolve()
+    if not candidate.is_relative_to(root):
+        raise ValueError("文件路径越界")
+    return candidate
+
+
+class InspectRepository(Tool):
+    name = "inspect_repository"
+    description = "读取全仓库静态清单：文件、函数/类/方法、签名、调用、入口、测试、资产和 README 摘要。"
+    parameters = {"type": "object", "properties": {}, "additionalProperties": False}
+
+    def __init__(self, ir: RepositoryIR) -> None:
+        self.ir = ir
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        return ToolResult(output=self.ir.to_json(indent=None))
+
+
+class ReadProjectFile(Tool):
+    name = "read_project_file"
+    description = "按仓库相对路径读取源码、测试、配置或文档；路径严格限制在用户提交目录内。"
+    parameters = {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "仓库相对路径"},
+            "start_line": {"type": "integer", "minimum": 1, "default": 1},
+            "end_line": {"type": "integer", "minimum": 1, "default": 400},
+        },
+        "required": ["path"],
+        "additionalProperties": False,
+    }
+
+    def __init__(self, project_dir: str | Path, *, max_chars: int = 60_000) -> None:
+        self.root = Path(project_dir).resolve()
+        self.max_chars = max_chars
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        path = _contained_path(self.root, str(kwargs.get("path", "")))
+        if not path.is_file() or path.is_symlink():
+            return ToolResult(error=f"文件不存在或不可读: {kwargs.get('path', '')}")
+        start = max(1, int(kwargs.get("start_line", 1)))
+        end = max(start, min(start + 999, int(kwargs.get("end_line", 400))))
+        text = path.read_text(encoding="utf-8", errors="replace")
+        selected = "\n".join(text.splitlines()[start - 1:end])
+        if len(selected) > self.max_chars:
+            selected = selected[: self.max_chars] + "\n...(truncated)"
+        return ToolResult(output=f"# {path.relative_to(self.root)} lines {start}-{end}\n{selected}")
+
+
+@dataclass
+class PlanStore:
+    path: Path
+    known_symbols: set[str]
+    known_files: set[str] | None = None
+    symbol_required_parameters: dict[str, list[str]] | None = None
+    symbol_calls: dict[str, list[str]] | None = None
+    symbol_is_generator: dict[str, bool] | None = None
+    candidate_symbols: set[str] | None = None
+    plan: PackagingPlan | None = None
+    last_errors: list[str] | None = None
+
+
+class SavePackagingPlan(Tool):
+    name = "save_packaging_plan"
+    description = "提交语义封装规划。规划会立即做结构、源码证据、工具唯一性和依赖校验；错误必须修复后重提。"
+    parameters = PLAN_JSON_SCHEMA
+
+    def __init__(self, store: PlanStore) -> None:
+        self.store = store
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        normalized = dict(kwargs)
+        for field in ("services", "excludedSymbols", "assumptions", "riskNotes", "rejectionReasons"):
+            value = normalized.get(field)
+            if not isinstance(value, str):
+                continue
+            if value.strip().startswith(("[", "{")):
+                parsed = _parse_structured_string(value)
+                if parsed is not None:
+                    normalized[field] = parsed
+            elif field in {"excludedSymbols", "assumptions", "riskNotes", "rejectionReasons"}:
+                normalized[field] = [
+                    re.sub(r"^\s*(?:[-*]|\d+[.)、])\s*", "", line).strip()
+                    for line in value.splitlines()
+                    if re.sub(r"^\s*(?:[-*]|\d+[.)、])\s*", "", line).strip()
+                ]
+        if isinstance(normalized.get("services"), str):
+            self.store.plan = None
+            self.store.last_errors = [
+                "services 被模型序列化成了无法解析的字符串；请改用 save_packaging_plan_json 提交整份严格 JSON"
+            ]
+            return ToolResult(error=self.store.last_errors[0])
+        try:
+            plan = PackagingPlan.validate(
+                normalized,
+                known_symbols=self.store.known_symbols,
+                known_files=self.store.known_files,
+                symbol_required_parameters=self.store.symbol_required_parameters,
+                symbol_calls=self.store.symbol_calls,
+                symbol_is_generator=self.store.symbol_is_generator,
+                candidate_symbols=self.store.candidate_symbols,
+            )
+        except PlanValidationError as exc:
+            self.store.plan = None
+            self.store.last_errors = exc.errors
+            return ToolResult(
+                error=(
+                    "规划校验失败。save_packaging_plan 不是 PATCH；下一次必须重新提交包含 "
+                    "schemaVersion、decision、analysisSummary、services 在内的完整规划:\n- "
+                    + "\n- ".join(exc.errors)
+                )
+            )
+        self.store.path.parent.mkdir(parents=True, exist_ok=True)
+        self.store.path.write_text(plan.to_json() + "\n", encoding="utf-8")
+        self.store.plan = plan
+        self.store.last_errors = None
+        return ToolResult(
+            output=(
+                f"规划已保存：decision={plan.decision}, "
+                f"services={len(plan.data.get('services', []))}, tools={len(plan.tools)}"
+            )
+        )
+
+
+class SavePackagingPlanJson(Tool):
+    name = "save_packaging_plan_json"
+    description = (
+        "当复杂 services 被函数调用序列化损坏时，以一段严格 JSON 文本提交完整规划；"
+        "内容仍执行与 save_packaging_plan 完全相同的所有质量门禁。"
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "完整规划 JSON；不能使用 Markdown code fence、Python repr 或局部 PATCH",
+            }
+        },
+        "required": ["content"],
+        "additionalProperties": False,
+    }
+
+    def __init__(self, store: PlanStore) -> None:
+        self.store = store
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        content = str(kwargs.get("content", "")).strip()
+        try:
+            raw = json.loads(content)
+        except json.JSONDecodeError as exc:
+            self.store.plan = None
+            self.store.last_errors = [
+                f"完整规划不是严格 JSON: line={exc.lineno}, column={exc.colno}, {exc.msg}"
+            ]
+            return ToolResult(error=self.store.last_errors[0])
+        if not isinstance(raw, dict):
+            self.store.plan = None
+            self.store.last_errors = ["完整规划 JSON 顶层必须是 object"]
+            return ToolResult(error=self.store.last_errors[0])
+        _canonicalize_nonsemantic_shape(raw)
+        return await SavePackagingPlan(self.store).execute(**raw)
+
+
+def _canonicalize_nonsemantic_shape(raw: dict[str, Any]) -> None:
+    """Repair provider formatting quirks without changing service semantics."""
+    services = raw.get("services")
+    if not isinstance(services, list):
+        return
+    for service in services:
+        if not isinstance(service, dict):
+            continue
+        service_id = service.get("id")
+        if (not isinstance(service_id, str) or not service_id.strip()) and isinstance(
+            service.get("name"), str
+        ):
+            service["id"] = _snake_identifier(service["name"], fallback="algorithm_service")
+        elif isinstance(service_id, str):
+            service["id"] = _snake_identifier(service_id, fallback="algorithm_service")
+        tools = service.get("tools")
+        if not isinstance(tools, list):
+            continue
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            if isinstance(tool.get("evidence"), str):
+                tool["evidence"] = [tool["evidence"]]
+            elif not tool.get("evidence") and isinstance(tool.get("sourceSymbols"), list):
+                tool["evidence"] = list(tool["sourceSymbols"])
+            smoke = tool.get("smokeTest")
+            if isinstance(smoke, dict) and isinstance(smoke.get("evidence"), str):
+                smoke["evidence"] = [smoke["evidence"]]
+
+
+def _snake_identifier(value: str, *, fallback: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    if not normalized or not normalized[0].isalpha():
+        normalized = fallback
+    return normalized[:64]
+
+
+def _parse_structured_string(value: str) -> Any | None:
+    """Normalize JSON/Python-like composites emitted as strings by some models."""
+    text = value.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    try:
+        return ast.literal_eval(text)
+    except (ValueError, SyntaxError):
+        pass
+    try:
+        tokens = []
+        replacements = {"true": "True", "false": "False", "null": "None"}
+        for token in tokenize.generate_tokens(io.StringIO(text).readline):
+            if token.type == tokenize.NAME and token.string in replacements:
+                token = tokenize.TokenInfo(
+                    token.type,
+                    replacements[token.string],
+                    token.start,
+                    token.end,
+                    token.line,
+                )
+            tokens.append(token)
+        return ast.literal_eval(tokenize.untokenize(tokens))
+    except (ValueError, SyntaxError, tokenize.TokenError, IndentationError):
+        return None
+
+
+class WriteArtifactFile(Tool):
+    name = "write_artifact_file"
+    description = "写入 Agent 负责的语义适配实现。只能写 adapters.py、README.generated.md 或 tests/ 下文本文件；server.py 由已审核规划确定性生成。"
+    parameters = {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "content": {"type": "string"},
+        },
+        "required": ["path", "content"],
+        "additionalProperties": False,
+    }
+
+    def __init__(self, artifact_dir: str | Path, *, max_chars: int = 250_000) -> None:
+        self.root = Path(artifact_dir).resolve()
+        self.max_chars = max_chars
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        relative = str(kwargs.get("path", ""))
+        content = str(kwargs.get("content", ""))
+        allowed = relative in {"adapters.py", "README.generated.md"} or (
+            relative.startswith("tests/") and relative.endswith((".py", ".json", ".md"))
+        )
+        if not allowed:
+            return ToolResult(error=f"不允许 Agent 写入该路径: {relative}")
+        if len(content) > self.max_chars:
+            return ToolResult(error=f"文件内容超过限制: {len(content)} > {self.max_chars}")
+        path = _contained_path(self.root, relative)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return ToolResult(output=f"已写入 {relative} ({len(content)} chars)")
+
+
+class ReadArtifactFile(Tool):
+    name = "read_artifact_file"
+    description = "读取当前生成产物中的文本文件，用于定位验收失败和修复。"
+    parameters = {
+        "type": "object",
+        "properties": {"path": {"type": "string"}},
+        "required": ["path"],
+        "additionalProperties": False,
+    }
+
+    def __init__(self, artifact_dir: str | Path, *, max_chars: int = 80_000) -> None:
+        self.root = Path(artifact_dir).resolve()
+        self.max_chars = max_chars
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        path = _contained_path(self.root, str(kwargs.get("path", "")))
+        if not path.is_file() or path.is_symlink():
+            return ToolResult(error="产物文件不存在")
+        text = path.read_text(encoding="utf-8", errors="replace")
+        return ToolResult(output=text[: self.max_chars] + ("\n...(truncated)" if len(text) > self.max_chars else ""))
+
+
+class VerifyArtifact(Tool):
+    name = "verify_artifact"
+    description = "运行确定性验收：规划一致性、MCP Tool 注册、参数 Schema、语法、传输端点、依赖和容器文件。"
+    parameters = {"type": "object", "properties": {}, "additionalProperties": False}
+
+    def __init__(self, artifact_dir: str | Path, plan: PackagingPlan) -> None:
+        self.verifier = ArtifactVerifier(artifact_dir, plan)
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        report = self.verifier.verify()
+        output = report.to_json()
+        return ToolResult(output=output if report.passed else "验收失败:\n" + output)

--- a/micro_agent/packaging/verifier.py
+++ b/micro_agent/packaging/verifier.py
@@ -1,0 +1,606 @@
+"""Deterministic acceptance gate for Agent-generated MCP artifacts."""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from micro_agent.packaging.models import PackagingPlan, PlanValidationError
+from micro_agent.packaging.analyzer import RepositoryAnalyzer, RepositoryIR
+
+
+REQUIRED_FILES = {
+    "server.py", "adapters.py", "requirements.txt", "Dockerfile",
+    "docker-compose.yml", "packaging_plan.json", "ioeb-service.json",
+    "algorithm_loader.py", "runtime_guardrails.py",
+}
+
+
+@dataclass
+class VerificationReport:
+    passed: bool
+    checks: dict[str, Any] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=2)
+
+
+class ArtifactVerifier:
+    def __init__(self, artifact_dir: str | Path, expected_plan: PackagingPlan) -> None:
+        self.root = Path(artifact_dir).resolve()
+        self.expected_plan = expected_plan
+
+    def verify(self) -> VerificationReport:
+        report = VerificationReport(passed=False)
+        ready_marker = self.root / ".ioeb-ready"
+        ready_marker.unlink(missing_ok=True)
+
+        if not self.root.is_dir():
+            report.errors.append("产物目录不存在")
+            return report
+
+        self._check_paths(report)
+        self._check_required_files(report)
+        actual_plan = self._check_plan(report)
+        self._check_python(report, actual_plan or self.expected_plan)
+        self._check_adapter_source_boundary(report)
+        self._check_dependencies(report)
+        self._check_container_files(report)
+        self._check_manifest(report)
+        self._check_source_copy(report)
+        report.checks["smokeTestsPlanned"] = sum(
+            1 for tool in self.expected_plan.tools if tool.get("smokeTest", {}).get("enabled")
+        )
+        if report.checks["smokeTestsPlanned"] == 0:
+            report.warnings.append("Agent 未找到可在容器内自动执行的 smoke test 输入")
+        report.passed = not report.errors
+        return report
+
+    def _check_paths(self, report: VerificationReport) -> None:
+        symlinks = [str(path.relative_to(self.root)) for path in self.root.rglob("*") if path.is_symlink()]
+        report.checks["symlinkCount"] = len(symlinks)
+        if symlinks:
+            report.errors.append(f"产物中不允许符号链接: {', '.join(symlinks[:5])}")
+
+    def _check_required_files(self, report: VerificationReport) -> None:
+        missing = sorted(name for name in REQUIRED_FILES if not (self.root / name).is_file())
+        report.checks["requiredFiles"] = sorted(REQUIRED_FILES)
+        if missing:
+            report.errors.append(f"缺少必要文件: {', '.join(missing)}")
+
+    def _check_plan(self, report: VerificationReport) -> PackagingPlan | None:
+        path = self.root / "packaging_plan.json"
+        if not path.is_file():
+            return None
+        try:
+            plan = PackagingPlan.validate(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError, PlanValidationError) as exc:
+            report.errors.append(f"packaging_plan.json 无效: {exc}")
+            return None
+        report.checks["plannedTools"] = plan.tool_names
+        if plan.tool_names != self.expected_plan.tool_names:
+            report.errors.append(
+                "生成阶段擅自改变了已审核工具集合: "
+                f"expected={self.expected_plan.tool_names}, actual={plan.tool_names}"
+            )
+        return plan
+
+    def _check_python(self, report: VerificationReport, plan: PackagingPlan) -> None:
+        trees: dict[str, ast.Module] = {}
+        for name in ("server.py", "adapters.py"):
+            path = self.root / name
+            if not path.is_file():
+                continue
+            try:
+                source = path.read_text(encoding="utf-8")
+                trees[name] = ast.parse(source, filename=name)
+                compile(source, name, "exec")
+            except (OSError, SyntaxError) as exc:
+                report.errors.append(f"{name} 语法无效: {exc}")
+        if "server.py" not in trees:
+            return
+
+        decorated = _mcp_tool_functions(trees["server.py"])
+        report.checks["registeredTools"] = sorted(decorated)
+        planned = set(plan.tool_names)
+        actual = set(decorated)
+        if planned - actual:
+            report.errors.append(f"缺少 MCP Tool 注册: {', '.join(sorted(planned - actual))}")
+        if actual - planned:
+            report.errors.append(f"存在规划外 MCP Tool: {', '.join(sorted(actual - planned))}")
+
+        tool_by_name = {tool["name"]: tool for tool in plan.tools}
+        for name, function in decorated.items():
+            if name not in tool_by_name:
+                continue
+            if not (ast.get_docstring(function) or "").strip():
+                report.errors.append(f"MCP Tool {name} 缺少 docstring")
+            expected_args = set(tool_by_name[name]["inputSchema"].get("properties", {}).keys())
+            actual_args = {
+                arg.arg
+                for arg in [*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs]
+                if arg.arg not in {"self", "ctx", "context"}
+            }
+            if function.args.vararg or function.args.kwarg:
+                report.errors.append(f"MCP Tool {name} 不允许 *args/**kwargs，必须暴露明确 JSON Schema")
+            if expected_args != actual_args:
+                report.errors.append(
+                    f"MCP Tool {name} 参数与规划不一致: expected={sorted(expected_args)}, actual={sorted(actual_args)}"
+                )
+            for arg in [*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs]:
+                if arg.arg not in {"self", "ctx", "context"} and arg.annotation is None:
+                    report.errors.append(f"MCP Tool {name} 参数 {arg.arg} 缺少类型注解")
+            if function.returns is None:
+                report.errors.append(f"MCP Tool {name} 缺少返回类型注解")
+
+        adapter_functions = _top_level_functions(trees.get("adapters.py"))
+        report.checks["adapterFunctions"] = sorted(name for name in adapter_functions if name in planned)
+        missing_adapters = planned - set(adapter_functions)
+        if missing_adapters:
+            report.errors.append(f"缺少同名语义适配函数: {', '.join(sorted(missing_adapters))}")
+        for name in planned & set(adapter_functions):
+            function = adapter_functions[name]
+            expected_args = set(tool_by_name[name]["inputSchema"].get("properties", {}).keys())
+            actual_args = {
+                arg.arg
+                for arg in [*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs]
+                if arg.arg != "self"
+            }
+            if expected_args != actual_args or function.args.vararg or function.args.kwarg:
+                report.errors.append(
+                    f"适配函数 {name} 参数与规划不一致: expected={sorted(expected_args)}, actual={sorted(actual_args)}"
+                )
+            if _returns_from_except(function):
+                report.errors.append(
+                    f"适配函数 {name} 在 except 中返回普通结果，会把执行失败伪装成成功；必须抛出异常"
+                )
+
+        self._check_source_failure_sentinels(
+            report,
+            adapter_functions,
+            tool_by_name,
+            trees.get("adapters.py"),
+        )
+
+        if "adapters.py" in trees:
+            self._check_algorithm_imports(report, trees["adapters.py"])
+            imported_bindings = _imported_bound_names(trees["adapters.py"])
+            shadowed = sorted(planned & imported_bindings & set(adapter_functions))
+            if shadowed:
+                report.errors.append(
+                    "适配函数覆盖了同名源码导入并会递归调用: " + ", ".join(shadowed)
+                    + "；源码导入必须使用 alias"
+                )
+
+        server_text = (self.root / "server.py").read_text(encoding="utf-8")
+        for required_import in (
+            "from mcp.server.fastmcp import FastMCP",
+        ):
+            if required_import not in server_text:
+                report.errors.append(f"server.py 缺少协议基线导入: {required_import}")
+        if "mcp = FastMCP(" not in server_text or "mcp.sse_app(" not in server_text:
+            report.errors.append("server.py 未通过 FastMCP.sse_app() 初始化版本兼容的 SSE transport")
+        if '"/sse"' not in server_text and "'/sse'" not in server_text:
+            report.errors.append("server.py 未暴露 /sse 端点")
+        if '"/messages/"' not in server_text and "'/messages/'" not in server_text:
+            report.errors.append("server.py 未挂载 /messages/ 端点")
+
+    def _check_dependencies(self, report: VerificationReport) -> None:
+        path = self.root / "requirements.txt"
+        if not path.is_file():
+            return
+        text = path.read_text(encoding="utf-8", errors="replace").lower()
+        missing = [name for name in ("mcp", "starlette", "uvicorn") if name not in text]
+        if missing:
+            report.errors.append(f"requirements.txt 缺少运行依赖: {', '.join(missing)}")
+
+    def _check_source_failure_sentinels(
+        self,
+        report: VerificationReport,
+        adapter_functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef],
+        tool_by_name: dict[str, dict[str, Any]],
+        adapter_tree: ast.Module | None,
+    ) -> None:
+        algorithm_root = self.root / "algorithm"
+        if not algorithm_root.is_dir():
+            return
+        try:
+            ir = RepositoryAnalyzer().analyze(algorithm_root)
+        except (OSError, ValueError):
+            return
+        all_sentinels = {
+            symbol.qualifiedName: symbol.failureReturns
+            for symbol in ir.symbols
+            if symbol.failureReturns
+        }
+        report.checks["sourceFailureSentinels"] = all_sentinels
+        for tool_name, tool in tool_by_name.items():
+            risky = _reachable_failure_sentinels(
+                ir,
+                set(tool.get("sourceSymbols", [])),
+                all_sentinels,
+            )
+            function = adapter_functions.get(tool_name)
+            source_names = {
+                symbol.rsplit(".", 1)[-1]
+                for symbol in tool.get("sourceSymbols", [])
+            }
+            risky_names = _import_aliases_for_names(
+                adapter_tree,
+                source_names | {symbol.rsplit(".", 1)[-1] for symbol in risky},
+            )
+            if (
+                risky
+                and function is not None
+                and not _guards_failure_return_from_calls(function, risky_names)
+            ):
+                report.errors.append(
+                    f"适配函数 {tool_name} 调用的源码会把异常作为普通字符串返回，"
+                    "必须检查该源码调用的返回值并 raise，不能让 MCP 把失败标成成功: "
+                    + json.dumps(risky, ensure_ascii=False)
+                )
+
+    def _check_adapter_source_boundary(self, report: VerificationReport) -> None:
+        path = self.root / "adapters.py"
+        if not path.is_file():
+            return
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            return
+        unsafe_assets = _asset_literals_without_algorithm_root(tree, self.root / "algorithm")
+        if unsafe_assets:
+            report.errors.append(
+                "模型/资源路径未基于 algorithm_loader.ALGORITHM_DIR: "
+                + ", ".join(sorted(unsafe_assets))
+            )
+        if _has_runtime_guardrail_fallback(tree):
+            report.errors.append(
+                "runtime_guardrails 是只读必备模块，不允许捕获 ImportError 后提供占位/降级实现"
+            )
+        zip_inputs = _zip_input_names(self.expected_plan)
+        for tool_name, input_names in zip_inputs.items():
+            function = _top_level_functions(tree).get(tool_name)
+            if function is None:
+                continue
+            guarded = _direct_guarded_names(function)
+            missing = sorted(input_names - guarded)
+            if missing:
+                report.errors.append(
+                    f"适配函数 {tool_name} 必须将 Base64 ZIP 参数直接传给 "
+                    f"decode_safe_zip: {', '.join(missing)}"
+                )
+            double_decoded = sorted(input_names & _base64_decoded_names(function))
+            if double_decoded:
+                report.errors.append(
+                    f"适配函数 {tool_name} 对 ZIP 参数重复 Base64 解码: "
+                    + ", ".join(double_decoded)
+                )
+
+    def _check_algorithm_imports(self, report: VerificationReport, tree: ast.Module) -> None:
+        source_roots = _algorithm_module_roots(self.root / "algorithm")
+        loader_index: int | None = None
+        legacy_imports: list[tuple[int, str]] = []
+        top_level_import_ids: set[int] = set()
+        for index, node in enumerate(tree.body):
+            if not isinstance(node, (ast.Import, ast.ImportFrom)):
+                continue
+            top_level_import_ids.add(id(node))
+            modules = _imported_modules(node)
+            if any(module == "algorithm_loader" for module in modules):
+                loader_index = index if loader_index is None else min(loader_index, index)
+            for module in modules:
+                root = module.split(".", 1)[0]
+                if root in source_roots and root != "algorithm":
+                    legacy_imports.append((index, module))
+        nested_legacy = {
+            module
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom)) and id(node) not in top_level_import_ids
+            for module in _imported_modules(node)
+            if module.split(".", 1)[0] in source_roots
+            and module.split(".", 1)[0] != "algorithm"
+            and loader_index is None
+        }
+        invalid = sorted(
+            {module
+            for index, module in legacy_imports
+            if loader_index is None or loader_index >= index} | nested_legacy
+        )
+        if invalid:
+            report.errors.append(
+                "源码模块导入前必须先 `from algorithm_loader import ALGORITHM_DIR`，"
+                "确保原仓库及其旧式绝对导入从 algorithm/ 解析: " + ", ".join(invalid)
+            )
+
+    def _check_container_files(self, report: VerificationReport) -> None:
+        dockerfile = self.root / "Dockerfile"
+        if dockerfile.is_file():
+            text = dockerfile.read_text(encoding="utf-8", errors="replace")
+            if "CMD" not in text or "server.py" not in text:
+                report.errors.append("Dockerfile 未以 server.py 作为启动入口")
+            if "COPY ." not in text:
+                report.errors.append("Dockerfile 未复制完整产物")
+        compose = self.root / "docker-compose.yml"
+        if compose.is_file():
+            text = compose.read_text(encoding="utf-8", errors="replace")
+            if "build:" not in text:
+                report.errors.append("docker-compose.yml 缺少 build 配置")
+            if "volumes:" in text:
+                report.errors.append("部署产物不允许声明宿主机 volumes")
+
+    def _check_manifest(self, report: VerificationReport) -> None:
+        path = self.root / "ioeb-service.json"
+        if not path.is_file():
+            return
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            report.errors.append(f"ioeb-service.json 无效: {exc}")
+            return
+        if data.get("engine") != "agentic":
+            report.errors.append("ioeb-service.json 未声明 agentic 引擎")
+        if data.get("endpoint") != "/sse" or data.get("port") != 8000:
+            report.errors.append("ioeb-service.json 的传输端点配置不兼容当前平台")
+
+    def _check_source_copy(self, report: VerificationReport) -> None:
+        root = self.root / "algorithm"
+        python_files = list(root.rglob("*.py")) if root.is_dir() else []
+        report.checks["algorithmPythonFiles"] = len(python_files)
+        if not python_files:
+            report.errors.append("algorithm/ 中没有保留提交的 Python 源码")
+
+
+def _mcp_tool_functions(tree: ast.Module) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    result: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if any(_is_mcp_tool_decorator(decorator) for decorator in node.decorator_list):
+            result[node.name] = node
+    return result
+
+
+def _top_level_functions(
+    tree: ast.Module | None,
+) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    if tree is None:
+        return {}
+    return {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _returns_from_except(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for node in ast.walk(function):
+        if isinstance(node, ast.ExceptHandler) and any(
+            isinstance(child, ast.Return) for statement in node.body for child in ast.walk(statement)
+        ):
+            return True
+    return False
+
+
+def _guards_failure_return_from_calls(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    risky_call_names: set[str],
+) -> bool:
+    """Require a branch that raises based on a risky source call's result.
+
+    A generic input-validation ``raise`` is insufficient: the adapter must bind
+    the return value of the source callable and use that exact binding in the
+    condition which converts a failure sentinel into an exception.
+    """
+    risky_results: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if isinstance(value, ast.Await):
+            value = value.value
+        if not isinstance(value, ast.Call):
+            continue
+        call_name = _call_name(value.func)
+        if not call_name or call_name.rsplit(".", 1)[-1] not in risky_call_names:
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        risky_results.update(
+            child.id
+            for target in targets
+            for child in ast.walk(target)
+            if isinstance(child, ast.Name)
+        )
+
+    for node in ast.walk(function):
+        if not isinstance(node, ast.If):
+            continue
+        tested_names = {
+            child.id for child in ast.walk(node.test) if isinstance(child, ast.Name)
+        }
+        raises = any(
+            isinstance(child, ast.Raise)
+            for statement in node.body
+            for child in ast.walk(statement)
+        )
+        if raises and tested_names & risky_results:
+            return True
+    return False
+
+
+def _import_aliases_for_names(tree: ast.Module | None, names: set[str]) -> set[str]:
+    result = set(names)
+    if tree is None:
+        return result
+    for node in tree.body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for alias in node.names:
+            if alias.name in names:
+                result.add(alias.asname or alias.name)
+    return result
+
+
+def _reachable_failure_sentinels(
+    ir: RepositoryIR,
+    roots: set[str],
+    sentinels: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    """Find failure-returning source symbols reachable from planned roots."""
+    by_name = {symbol.qualifiedName: symbol for symbol in ir.symbols}
+    by_tail: dict[str, set[str]] = {}
+    for qualified in by_name:
+        by_tail.setdefault(qualified.rsplit(".", 1)[-1], set()).add(qualified)
+    visited: set[str] = set()
+    pending = list(roots)
+    while pending:
+        current = pending.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        symbol = by_name.get(current)
+        if symbol is None:
+            continue
+        for call in symbol.calls:
+            exact = {call} if call in by_name else set()
+            candidates = exact or by_tail.get(call.rsplit(".", 1)[-1], set())
+            pending.extend(candidates - visited)
+    return {symbol: sentinels[symbol] for symbol in visited if symbol in sentinels}
+
+
+def _call_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def _imported_bound_names(tree: ast.Module) -> set[str]:
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            names.update(alias.asname or alias.name for alias in node.names)
+        elif isinstance(node, ast.Import):
+            names.update(alias.asname or alias.name.split(".")[0] for alias in node.names)
+    return names
+
+
+def _zip_input_names(plan: PackagingPlan) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = {}
+    for tool in plan.tools:
+        properties = tool.get("inputSchema", {}).get("properties", {})
+        if not isinstance(properties, dict):
+            continue
+        for name, schema in properties.items():
+            description = str(schema.get("description", "")) if isinstance(schema, dict) else ""
+            combined = f"{name} {description}".lower()
+            if "zip" in combined and ("base64" in combined or "file" in combined):
+                result.setdefault(tool["name"], set()).add(name)
+    return result
+
+
+def _algorithm_module_roots(root: Path) -> set[str]:
+    if not root.is_dir():
+        return set()
+    result = {path.name for path in root.iterdir() if path.is_dir() and not path.name.startswith(".")}
+    result.update(path.stem for path in root.glob("*.py") if path.stem != "__init__")
+    return result
+
+
+def _imported_modules(node: ast.Import | ast.ImportFrom) -> list[str]:
+    if isinstance(node, ast.ImportFrom):
+        return [node.module or ""]
+    return [alias.name for alias in node.names]
+
+
+def _asset_literals_without_algorithm_root(tree: ast.Module, algorithm_root: Path) -> set[str]:
+    asset_names = {
+        path.name
+        for path in algorithm_root.rglob("*")
+        if path.is_file() and path.suffix.lower() not in {".py", ".pyc", ".md", ".txt"}
+    }
+    if not asset_names:
+        return set()
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+    invalid: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        matched = {name for name in asset_names if name in node.value}
+        if not matched:
+            continue
+        context: ast.AST = node
+        while context in parents and not isinstance(context, (ast.Assign, ast.AnnAssign, ast.Return, ast.Expr)):
+            context = parents[context]
+        if not any(isinstance(child, ast.Name) and child.id == "ALGORITHM_DIR" for child in ast.walk(context)):
+            invalid.update(matched)
+    return invalid
+
+
+def _has_runtime_guardrail_fallback(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if not isinstance(node, ast.Try):
+            continue
+        imports_guardrail = any(
+            isinstance(child, (ast.Import, ast.ImportFrom))
+            and "runtime_guardrails" in _imported_modules(child)
+            for statement in node.body
+            for child in ast.walk(statement)
+        )
+        if imports_guardrail and node.handlers:
+            return True
+    return False
+
+
+def _direct_guarded_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    result: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        target = node.func
+        is_guard = (
+            isinstance(target, ast.Name) and target.id == "decode_safe_zip"
+        ) or (
+            isinstance(target, ast.Attribute) and target.attr == "decode_safe_zip"
+        )
+        if is_guard and isinstance(node.args[0], ast.Name):
+            result.add(node.args[0].id)
+    return result
+
+
+def _base64_decoded_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    result: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        target = node.func
+        if (
+            isinstance(target, ast.Attribute)
+            and target.attr in {"b64decode", "decodebytes", "standard_b64decode"}
+            and isinstance(node.args[0], ast.Name)
+        ):
+            result.add(node.args[0].id)
+    return result
+
+
+def _is_mcp_tool_decorator(node: ast.expr) -> bool:
+    target = node.func if isinstance(node, ast.Call) else node
+    return (
+        isinstance(target, ast.Attribute)
+        and target.attr == "tool"
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "mcp"
+    )

--- a/micro_agent/packaging/workflow.py
+++ b/micro_agent/packaging/workflow.py
@@ -1,0 +1,455 @@
+"""Two-stage Agent workflow: semantic planning, implementation, verification, repair."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import time
+from collections import OrderedDict
+from pathlib import Path
+from typing import AsyncIterator
+
+from micro_agent.core.agent import Agent
+from micro_agent.core.config import config
+from micro_agent.core.llm import LLM
+from micro_agent.core.schema import AgentEvent
+from micro_agent.packaging.analyzer import RepositoryIR
+from micro_agent.packaging.models import PackagingPlan
+from micro_agent.packaging.scaffold import prepare_artifact
+from micro_agent.packaging.tools import (
+    InspectRepository,
+    PlanStore,
+    ReadArtifactFile,
+    ReadProjectFile,
+    SavePackagingPlanJson,
+    VerifyArtifact,
+    WriteArtifactFile,
+)
+from micro_agent.packaging.verifier import ArtifactVerifier, VerificationReport
+from micro_agent.tool.registry import ToolRegistry
+from micro_agent.tool.terminate import Terminate
+
+
+PLANNER_SYSTEM_PROMPT = """你是 IOEB 的 MCP 服务架构 Agent。你的职责不是逐函数机械加装饰器，而是从用户提交的完整算法仓库中抽象稳定、可理解、可测试的服务能力。
+
+必须遵守：
+1. 先用 inspect_repository 查看全仓库，再阅读 README、测试、入口和核心实现等证据；不能只看 main.py。
+2. 以用户意图划分 MCP Tool。数据加载、日志、格式转换、私有方法、get_model_info/health 等运维元数据通常不应成为 Tool；一个 Tool 可以编排多个源码符号。任何返回都不得泄露容器内模型路径或临时目录。
+3. services 表示逻辑服务边界。按模型生命周期、共享状态、领域内聚性和部署依赖划分，不得为了增加数量而拆分。
+4. 每个工具必须给出明确 JSON Schema、源码符号、证据、适配/重构策略和依赖关系。禁止把复杂输入一律降级成 JSON 字符串。
+   MCP 调用者无法访问容器文件系统，public schema 严禁暴露 data_path、save_dir、model_path 等服务端路径；上传、解压、预处理、推理等内部阶段必须组合成端到端用户能力。
+   同一组源码和相同输入输出只能形成一个工具，严禁仅换名字制造重复能力。直接封装单个源码函数时，Schema 必须提供调用它所需的全部必填信息。
+   inputSchema.required 必须覆盖执行所需的用户输入，不能为了绕过校验把源码必填参数标成可选；object 输出声明了 properties 时，outputSchema.required 必须标明稳定返回字段。
+   源码函数含 yield/YieldFrom 时是多结果生成器，面向 MCP 的 outputSchema 必须是 array（由适配层收集为可序列化列表），不能伪装成单个 object。
+5. 不得使用隐藏样例答案、文件名特判、伪实现或硬编码返回值。
+6. 如果仓库没有可调用算法、源码无法解析、关键实现/依赖/模型资产缺失，decision=reject 并给出可操作原因。
+7. schemaVersion 必须逐字填写 ioeb.agentic-mcp-plan/v1。dependsOn 只能填写本规划中其他 Tool 的 name；不要填写服务 id、源码模块、模型或文件名，无依赖时填 []。
+8. smokeTest 只能使用仓库中真实存在、可执行的 fixture，或从源码中明确的字段约束机械选择输入；enabled=true 时 evidence 必须引用对应仓库文件/行号。没有可追溯输入时必须 enabled=false 并写 rationale，绝不能编造 Base64、文件路径或预期输出。
+9. 每个公开函数/方法都必须可审计：被工具使用的写入 sourceSymbols，其余写入 excludedSymbols 并逐项说明为什么它只是内部实现或不适合远程调用。
+   独立的 predict/infer/evaluate/calculate/score/dose 等业务能力不能只以“非核心、内部使用、未来支持”为理由排除；只有调用图证明它已被某个端到端 sourceSymbol 组合时，才可作为内部子流程。
+10. 必须用 save_packaging_plan_json 提交一段无 Markdown fence 的完整严格 JSON。每次调用都是完整替换，不是局部 PATCH；校验失败后也必须重发包含非空 services 的完整规划，不能只发送修改字段。保存成功后调用 terminate。
+"""
+
+
+BUILDER_SYSTEM_PROMPT = """你是 IOEB 的 MCP 服务实现 Agent。你收到的 packaging_plan.json 已通过独立语义审核，你要把计划实现为真实可运行的 MCP 服务，而不是生成演示代码。
+
+必须遵守：
+1. 原始仓库已原样放在 algorithm/。阅读真实源码后，在 adapters.py 中完成参数校验、对象构造、数据转换、生命周期管理和结果序列化。
+2. server.py 已由审核后的工具名和 JSON Schema 确定性生成，是只读的协议边界。adapters.py 必须为每个计划工具实现一个同名、同参数的函数。
+3. 不复制或重写算法核心，不返回伪造结果，不做文件名/样例特判，不吞掉异常并伪装成功。
+   必须检查所有 sourceSymbols 是否在 except 中以“错误/失败/error/failed”等字符串作为普通返回值；若有，适配器必须识别该失败哨兵并 raise，使 MCP 返回 isError，而不是成功 payload。
+4. 产物内已有只读 algorithm_loader.py。adapters.py 必须先 `from algorithm_loader import ALGORITHM_DIR`，再导入 predictor、api、main 等原仓库模块；所有模型/资源路径必须以 ALGORITHM_DIR 开始，不能使用 adapters.py 所在目录冒充算法目录，也不能依赖进程当前目录。
+   源码函数必须用 alias 导入，避免适配函数覆盖同名导入后递归。任何执行异常都必须抛出，禁止返回“失败/错误”字符串伪装为成功。
+   若工具接收 Base64/ZIP，必须把原始字符串直接传给只读模块 runtime_guardrails.decode_safe_zip（该函数已经完成 Base64 解码和 ZIP 安全校验），再把返回的 BytesIO 交给原算法；禁止自行先 b64decode，也禁止给 guardrail 写 fallback。
+5. 只能用 write_artifact_file 写 adapters.py 和可选测试。不得使用 Bash、安装依赖、启动服务、覆盖 server.py、runtime_guardrails.py 或容器基线。
+6. 写完后必须调用 verify_artifact。若验收失败，阅读错误和现有文件，修复后重新验收。通过后调用 terminate。
+"""
+
+
+class AnalysisCache:
+    """Small immutable content-addressed cache joining the two existing UI calls."""
+
+    def __init__(self, *, max_entries: int = 32, ttl_seconds: int = 1800) -> None:
+        self.max_entries = max_entries
+        self.ttl_seconds = ttl_seconds
+        self._items: OrderedDict[str, tuple[float, dict]] = OrderedDict()
+
+    def get(self, fingerprint: str) -> PackagingPlan | None:
+        item = self._items.get(fingerprint)
+        if not item:
+            return None
+        created, raw = item
+        if time.monotonic() - created > self.ttl_seconds:
+            self._items.pop(fingerprint, None)
+            return None
+        self._items.move_to_end(fingerprint)
+        return PackagingPlan.validate(copy.deepcopy(raw))
+
+    def put(self, fingerprint: str, plan: PackagingPlan) -> None:
+        self._items[fingerprint] = (time.monotonic(), plan.to_dict())
+        self._items.move_to_end(fingerprint)
+        while len(self._items) > self.max_entries:
+            self._items.popitem(last=False)
+
+    def clear(self) -> None:
+        self._items.clear()
+
+
+analysis_cache = AnalysisCache()
+
+
+class AgenticAnalysisWorkflow:
+    """Run repository inspection and semantic planning for the existing analysis SSE."""
+
+    def __init__(self, *, project_dir: str | Path, ir: RepositoryIR, graph_path: str | Path) -> None:
+        self.project_dir = Path(project_dir).resolve()
+        self.ir = ir
+        self.graph_path = Path(graph_path).resolve()
+        self.plan_store = PlanStore(
+            path=self.graph_path.with_name("packaging_plan.json"),
+            known_symbols=ir.known_symbols,
+            known_files={file.path for file in ir.files},
+            symbol_required_parameters={
+                symbol.qualifiedName: symbol.requiredParameters for symbol in ir.symbols
+            },
+            symbol_calls={symbol.qualifiedName: symbol.calls for symbol in ir.symbols},
+            symbol_is_generator={symbol.qualifiedName: symbol.isGenerator for symbol in ir.symbols},
+            candidate_symbols=ir.public_callable_symbols,
+        )
+        self.agent = _build_planning_agent(self.project_dir, ir, self.plan_store)
+
+    def cancel(self) -> None:
+        self.agent.cancel()
+
+    async def run(self, request: str) -> AsyncIterator[AgentEvent]:
+        yield AgentEvent(
+            type="think",
+            step=0,
+            data={
+                "thought": (
+                    f"[全仓库证据提取] 已扫描 {len(self.ir.files)} 个文件、"
+                    f"{len(self.ir.symbols)} 个源码符号、{len(self.ir.testFiles)} 个测试文件；"
+                    "开始由 Agent 规划服务边界与 MCP 能力。"
+                )
+            },
+        )
+        async for event in _run_planner(self.agent, self.plan_store, self.ir, request):
+            yield event
+
+        plan = self.plan_store.plan
+        if plan is None:
+            yield AgentEvent(type="error", step=99, data={"error": _plan_failure(self.plan_store)})
+            return
+        if plan.decision == "reject":
+            reasons = "；".join(plan.data.get("rejectionReasons", []))
+            yield AgentEvent(type="error", step=99, data={"error": f"提交不满足自动封装要求：{reasons}"})
+            return
+
+        self.graph_path.parent.mkdir(parents=True, exist_ok=True)
+        self.graph_path.write_text(
+            json.dumps(plan.to_frontend_graph(), ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        analysis_cache.put(self.ir.fingerprint, plan)
+        yield AgentEvent(
+            type="done",
+            step=100,
+            data={
+                "result": (
+                    f"Agent 规划完成：{len(plan.data['services'])} 个逻辑服务边界、"
+                    f"{len(plan.tools)} 个 MCP 工具。"
+                )
+            },
+        )
+
+
+class AgenticPackagingWorkflow:
+    """Generate an artifact, then force the same Agent through bounded repairs."""
+
+    def __init__(
+        self,
+        *,
+        project_dir: str | Path,
+        ir: RepositoryIR,
+        artifact_dir: str | Path,
+        plan: PackagingPlan | None = None,
+        max_repairs: int = 2,
+    ) -> None:
+        self.project_dir = Path(project_dir).resolve()
+        self.ir = ir
+        self.artifact_dir = Path(artifact_dir).resolve()
+        self.plan = plan
+        self.max_repairs = max_repairs
+        self._active_agent: Agent | None = None
+
+    def cancel(self) -> None:
+        if self._active_agent:
+            self._active_agent.cancel()
+
+    async def run(self, request: str) -> AsyncIterator[AgentEvent]:
+        step_offset = 0
+        if self.plan is None:
+            plan_store = PlanStore(
+                path=self.artifact_dir.parent / "packaging_plan.json",
+                known_symbols=self.ir.known_symbols,
+                known_files={file.path for file in self.ir.files},
+                symbol_required_parameters={
+                    symbol.qualifiedName: symbol.requiredParameters for symbol in self.ir.symbols
+                },
+                symbol_calls={symbol.qualifiedName: symbol.calls for symbol in self.ir.symbols},
+                symbol_is_generator={
+                    symbol.qualifiedName: symbol.isGenerator for symbol in self.ir.symbols
+                },
+                candidate_symbols=self.ir.public_callable_symbols,
+            )
+            planner = _build_planning_agent(self.project_dir, self.ir, plan_store)
+            self._active_agent = planner
+            yield AgentEvent(
+                type="think",
+                step=0,
+                data={"thought": "未命中同文件分析缓存，先运行 Agent 语义规划阶段。"},
+            )
+            async for event in _run_planner(planner, plan_store, self.ir, request):
+                step_offset = max(step_offset, event.step + 1)
+                yield event
+            self.plan = plan_store.plan
+            if self.plan is None:
+                yield AgentEvent(type="error", step=step_offset, data={"error": _plan_failure(plan_store)})
+                return
+            if self.plan.decision == "reject":
+                reasons = "；".join(self.plan.data.get("rejectionReasons", []))
+                yield AgentEvent(type="error", step=step_offset, data={"error": f"提交不满足自动封装要求：{reasons}"})
+                return
+            analysis_cache.put(self.ir.fingerprint, self.plan)
+
+        plan = self.plan
+        assert plan is not None
+        prepare_artifact(self.project_dir, self.artifact_dir, plan)
+        yield AgentEvent(
+            type="think",
+            step=step_offset,
+            data={
+                "thought": (
+                    f"[隔离产物准备] 已复制完整算法仓库并固化部署基线；"
+                    f"协议层已从审核规划确定性生成；现在由实现 Agent 生成 {len(plan.tools)} 个工具的语义适配层。"
+                )
+            },
+        )
+        step_offset += 1
+
+        builder = _build_builder_agent(self.project_dir, self.artifact_dir, plan, self.ir)
+        self._active_agent = builder
+        report: VerificationReport | None = None
+        for attempt in range(self.max_repairs + 1):
+            prompt = _builder_prompt(plan, self.ir) if attempt == 0 else _repair_prompt(report, attempt)
+            async for event in builder.run(prompt):
+                if event.type == "done":
+                    continue
+                forwarded = AgentEvent(type=event.type, step=step_offset + event.step, data=event.data)
+                yield forwarded
+            step_offset += builder.max_steps + 1
+
+            report = ArtifactVerifier(self.artifact_dir, plan).verify()
+            (self.artifact_dir / "verification_report.json").write_text(
+                report.to_json() + "\n", encoding="utf-8"
+            )
+            if report.passed:
+                marker = {
+                    "schemaVersion": "ioeb.mcp-artifact-ready/v1",
+                    "repositoryFingerprint": self.ir.fingerprint,
+                    "planSha256": hashlib.sha256(plan.to_json(indent=None).encode("utf-8")).hexdigest(),
+                    "toolCount": len(plan.tools),
+                    "repairAttempts": attempt,
+                }
+                (self.artifact_dir / ".ioeb-ready").write_text(
+                    json.dumps(marker, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+                )
+                yield AgentEvent(
+                    type="done",
+                    step=step_offset,
+                    data={
+                        "result": (
+                            f"Agent 封装通过验收：{len(plan.tools)} 个工具，"
+                            f"修复循环 {attempt} 次。"
+                        )
+                    },
+                )
+                return
+
+            if attempt < self.max_repairs:
+                yield AgentEvent(
+                    type="think",
+                    step=step_offset,
+                    data={
+                        "thought": (
+                            f"[独立验收未通过] 发现 {len(report.errors)} 个问题，"
+                            f"将验收报告退回同一 Agent，进行第 {attempt + 1} 次定向修复。"
+                        ),
+                        "verification_errors": report.errors,
+                    },
+                )
+                step_offset += 1
+
+        assert report is not None
+        yield AgentEvent(
+            type="error",
+            step=step_offset,
+            data={
+                "error": (
+                    "Agent 生成产物经过有限修复后仍未通过验收，已阻止发布：\n- "
+                    + "\n- ".join(report.errors)
+                )
+            },
+        )
+
+
+async def _run_planner(
+    agent: Agent,
+    store: PlanStore,
+    ir: RepositoryIR,
+    user_request: str,
+) -> AsyncIterator[AgentEvent]:
+    step_offset = 0
+    for attempt in range(3):
+        prompt = _planner_prompt(ir, user_request) if attempt == 0 else (
+            "你尚未提交一个有效规划。必须使用 save_packaging_plan_json 重新发送完整严格 JSON；"
+            "这不是 PATCH，decision=package 时 services 绝对不能省略或为空。"
+            + ("\n上次校验错误：\n- " + "\n- ".join(store.last_errors) if store.last_errors else "")
+        )
+        async for event in agent.run(prompt):
+            if event.type == "done":
+                continue
+            yield AgentEvent(type=event.type, step=step_offset + event.step, data=event.data)
+        if store.plan is not None:
+            return
+        step_offset += agent.max_steps + 1
+        yield AgentEvent(
+            type="think",
+            step=step_offset,
+            data={"thought": "[规划质量门禁] 未收到有效结构化规划，要求 Agent 根据校验反馈重试。"},
+        )
+
+
+def _build_planning_agent(project_dir: Path, ir: RepositoryIR, store: PlanStore) -> Agent:
+    tools = ToolRegistry()
+    tools.register(InspectRepository(ir))
+    tools.register(ReadProjectFile(project_dir))
+    tools.register(SavePackagingPlanJson(store))
+    tools.register(Terminate())
+    return Agent(
+        name="mcp_service_architect",
+        llm=LLM(config.get_llm("reasoning")),
+        tools=tools,
+        system_prompt=PLANNER_SYSTEM_PROMPT,
+        max_steps=24,
+        max_observe=50_000,
+    )
+
+
+def _build_builder_agent(
+    project_dir: Path,
+    artifact_dir: Path,
+    plan: PackagingPlan,
+    ir: RepositoryIR,
+) -> Agent:
+    tools = ToolRegistry()
+    tools.register(InspectRepository(ir))
+    tools.register(ReadProjectFile(project_dir))
+    tools.register(ReadArtifactFile(artifact_dir))
+    tools.register(WriteArtifactFile(artifact_dir))
+    tools.register(VerifyArtifact(artifact_dir, plan))
+    tools.register(Terminate())
+    return Agent(
+        name="mcp_service_builder",
+        llm=LLM(config.get_llm("reasoning")),
+        tools=tools,
+        system_prompt=BUILDER_SYSTEM_PROMPT,
+        max_steps=30,
+        max_observe=50_000,
+    )
+
+
+def _planner_prompt(ir: RepositoryIR, user_request: str) -> str:
+    public_symbols = [
+        {
+            "qualifiedName": symbol.qualifiedName,
+            "kind": symbol.kind,
+            "file": symbol.file,
+            "signature": symbol.signature,
+            "docstring": symbol.docstring[:240],
+            "calls": symbol.calls[:15],
+            "isGenerator": symbol.isGenerator,
+        }
+        for symbol in ir.symbols
+        if symbol.isPublic
+    ][:160]
+    overview = {
+        "fingerprint": ir.fingerprint,
+        "fileCount": len(ir.files),
+        "symbolCount": len(ir.symbols),
+        "entrypointHints": ir.entrypointHints,
+        "testFiles": ir.testFiles,
+        "assetFiles": ir.assetFiles,
+        "documentationFiles": list(ir.documentation),
+        "parseErrors": ir.parseErrors,
+        "publicSymbols": public_symbols,
+        "truncated": ir.truncated,
+    }
+    return (
+        "请分析这个算法仓库，规划可投入真实使用的 MCP 服务。\n"
+        f"用户请求补充：{user_request or '无'}\n"
+        "以下只是索引，必须使用工具读取证据后再决策：\n"
+        + json.dumps(overview, ensure_ascii=False, indent=2)
+    )
+
+
+def _builder_prompt(plan: PackagingPlan, ir: RepositoryIR) -> str:
+    files_by_symbol = {
+        symbol.qualifiedName: {
+            "file": symbol.file,
+            "line": symbol.line,
+            "signature": symbol.signature,
+            "calls": symbol.calls,
+        }
+        for symbol in ir.symbols
+        if symbol.qualifiedName in {name for tool in plan.tools for name in tool["sourceSymbols"]}
+    }
+    for symbol in ir.symbols:
+        if symbol.qualifiedName in files_by_symbol and symbol.failureReturns:
+            files_by_symbol[symbol.qualifiedName]["failureReturns"] = symbol.failureReturns
+    return (
+        "请实现以下已审核规划。先阅读所有 sourceSymbols 对应源码及其必要依赖，再只写 adapters.py（server.py 是只读协议边界）。\n"
+        "inspect_repository 可查看完整提交清单；read_project_file 的路径相对提交仓库，不能加 algorithm/ 前缀；"
+        "read_artifact_file 才用于查看 server.py、algorithm_loader.py 等生成产物。\n"
+        "源码导入的标准前缀是 `from algorithm_loader import ALGORITHM_DIR`，它必须出现在 predictor/api/main 等提交模块导入之前。\n"
+        "sourceSymbols 索引：\n"
+        + json.dumps(files_by_symbol, ensure_ascii=False, indent=2)
+        + "\n仓库中已静态发现的失败字符串返回（包括 sourceSymbols 的下游调用，必须追踪）：\n"
+        + json.dumps(
+            {
+                symbol.qualifiedName: symbol.failureReturns
+                for symbol in ir.symbols
+                if symbol.failureReturns
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n完整规划：\n"
+        + plan.to_json()
+    )
+
+
+def _repair_prompt(report: VerificationReport | None, attempt: int) -> str:
+    return (
+        f"这是第 {attempt} 次定向修复。独立验收报告如下。请阅读现有 server.py/adapters.py，"
+        "只修复 adapters.py 中报告指出的问题；不得改变 server.py、packaging_plan.json 或删除计划中的工具。"
+        "修复后再次调用 verify_artifact。\n"
+        + (report.to_json() if report else "无验收报告")
+    )
+
+
+def _plan_failure(store: PlanStore) -> str:
+    if store.last_errors:
+        return "Agent 未能提交有效封装规划：\n- " + "\n- ".join(store.last_errors)
+    return "Agent 在有限步骤内未调用 save_packaging_plan，已终止任务。"

--- a/scripts/evaluate_agentic_packaging.py
+++ b/scripts/evaluate_agentic_packaging.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Run one reproducible Agent planning/packaging evaluation outside the web UI."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shutil
+import time
+from pathlib import Path
+
+from micro_agent.packaging.analyzer import RepositoryAnalyzer
+from micro_agent.packaging.models import PackagingPlan
+from micro_agent.packaging.workflow import AgenticAnalysisWorkflow, AgenticPackagingWorkflow
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("project", type=Path, help="Extracted algorithm repository root")
+    parser.add_argument("--output", type=Path, required=True, help="Evaluation output directory")
+    parser.add_argument("--plan-only", action="store_true", help="Stop after semantic planning")
+    parser.add_argument("--plan-file", type=Path, help="Reuse a previously reviewed plan and skip the planning Agent")
+    return parser.parse_args()
+
+
+async def main() -> int:
+    args = parse_args()
+    project = args.project.resolve()
+    output = args.output.resolve()
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    ir = RepositoryAnalyzer().analyze(project)
+    (output / "repository_ir.json").write_text(ir.to_json(indent=2) + "\n", encoding="utf-8")
+    event_log = output / "events.jsonl"
+    analysis_events = []
+    if args.plan_file:
+        plan = PackagingPlan.validate(
+            json.loads(args.plan_file.read_text(encoding="utf-8")),
+            known_symbols=ir.known_symbols,
+            known_files={file.path for file in ir.files},
+            symbol_required_parameters={
+                symbol.qualifiedName: symbol.requiredParameters for symbol in ir.symbols
+            },
+            symbol_calls={symbol.qualifiedName: symbol.calls for symbol in ir.symbols},
+            symbol_is_generator={symbol.qualifiedName: symbol.isGenerator for symbol in ir.symbols},
+            candidate_symbols=ir.public_callable_symbols,
+        )
+        analysis_seconds = 0.0
+        (output / "function.json").write_text(
+            json.dumps(plan.to_frontend_graph(), ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+    else:
+        graph_path = output / "function.json"
+        analysis = AgenticAnalysisWorkflow(project_dir=project, ir=ir, graph_path=graph_path)
+        analysis_started = time.perf_counter()
+        async for event in analysis.run("独立算法封装评测"):
+            analysis_events.append(event)
+            _append_event(event_log, "analysis", event)
+            _print_event("analysis", event)
+        analysis_seconds = time.perf_counter() - analysis_started
+        plan = analysis.plan_store.plan
+    summary = {
+        "repositoryFingerprint": ir.fingerprint,
+        "filesScanned": len(ir.files),
+        "symbolsScanned": len(ir.symbols),
+        "parseErrorCount": len(ir.parseErrors),
+        "analysisSeconds": round(analysis_seconds, 3),
+        "decision": plan.decision if plan else "failed",
+        "serviceCount": len(plan.data.get("services", [])) if plan else 0,
+        "toolCount": len(plan.tools) if plan else 0,
+        "tools": plan.tool_names if plan else [],
+        "analysisErrors": [event.data.get("error", "") for event in analysis_events if event.type == "error"],
+        "artifactReady": False,
+    }
+    if plan:
+        (output / "packaging_plan.json").write_text(plan.to_json() + "\n", encoding="utf-8")
+
+    if not plan or plan.decision != "package":
+        _write_summary(output, summary)
+        return 2
+    if args.plan_only:
+        _write_summary(output, summary)
+        return 0
+
+    artifact = output / "artifact"
+    packaging = AgenticPackagingWorkflow(
+        project_dir=project,
+        ir=ir,
+        artifact_dir=artifact,
+        plan=plan,
+    )
+    packaging_started = time.perf_counter()
+    packaging_events = []
+    async for event in packaging.run("独立算法封装评测"):
+        packaging_events.append(event)
+        _append_event(event_log, "packaging", event)
+        _print_event("packaging", event)
+    packaging_seconds = time.perf_counter() - packaging_started
+    summary.update(
+        {
+            "packagingSeconds": round(packaging_seconds, 3),
+            "packagingErrors": [
+                event.data.get("error", "") for event in packaging_events if event.type == "error"
+            ],
+            "artifactReady": (artifact / ".ioeb-ready").is_file(),
+        }
+    )
+    if (artifact / ".ioeb-ready").is_file():
+        summary["readyMarker"] = json.loads((artifact / ".ioeb-ready").read_text(encoding="utf-8"))
+    if (artifact / "verification_report.json").is_file():
+        summary["verification"] = json.loads(
+            (artifact / "verification_report.json").read_text(encoding="utf-8")
+        )
+    _write_summary(output, summary)
+    return 0 if summary["artifactReady"] else 3
+
+
+def _append_event(path: Path, phase: str, event) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps({"phase": phase, **event.to_dict()}, ensure_ascii=False, default=str) + "\n"
+        )
+
+
+def _print_event(phase: str, event) -> None:
+    detail = event.data.get("tool") or event.data.get("error") or event.data.get("result")
+    if not detail:
+        detail = event.data.get("thought", "")
+    print(f"[{phase}] step={event.step} type={event.type} {str(detail)[:300]}", flush=True)
+
+
+def _write_summary(output: Path, summary: dict) -> None:
+    (output / "summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(summary, ensure_ascii=False, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/validate_mcp_artifact.py
+++ b/scripts/validate_mcp_artifact.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Validate a running generated artifact through the public MCP protocol."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from jsonschema import ValidationError, validate
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://127.0.0.1:8000/sse")
+    parser.add_argument("--plan", type=Path, default=Path("packaging_plan.json"))
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    return parser.parse_args()
+
+
+async def main() -> int:
+    args = parse_args()
+    plan = json.loads(args.plan.read_text(encoding="utf-8"))
+    planned_tools = [
+        tool
+        for service in plan.get("services", [])
+        for tool in service.get("tools", [])
+    ]
+    report: dict[str, Any] = {
+        "url": args.url,
+        "plannedTools": [tool["name"] for tool in planned_tools],
+        "discoveredTools": [],
+        "toolDiscoveryExact": False,
+        "smokeTests": [],
+        "securityTests": [],
+        "passed": False,
+    }
+    try:
+        async with sse_client(args.url, timeout=args.timeout) as streams:
+            async with ClientSession(*streams) as session:
+                await session.initialize()
+                listed = await session.list_tools()
+                report["discoveredTools"] = [tool.name for tool in listed.tools]
+                report["toolDiscoveryExact"] = set(report["discoveredTools"]) == set(report["plannedTools"])
+                for tool in planned_tools:
+                    smoke = tool.get("smokeTest", {})
+                    if not smoke.get("enabled"):
+                        continue
+                    started = time.perf_counter()
+                    case = {
+                        "tool": tool["name"],
+                        "passed": False,
+                        "latencyMs": 0.0,
+                        "error": None,
+                    }
+                    try:
+                        result = await session.call_tool(tool["name"], smoke.get("input", {}))
+                        case["latencyMs"] = round((time.perf_counter() - started) * 1000, 3)
+                        if result.isError:
+                            case["error"] = _content_text(result)
+                        else:
+                            value = _structured_value(result, tool.get("outputSchema", {}))
+                            validate(instance=value, schema=tool.get("outputSchema", {}))
+                            case["passed"] = True
+                            case["outputPreview"] = _preview(value)
+                    except (Exception, ValidationError) as exc:
+                        case["latencyMs"] = round((time.perf_counter() - started) * 1000, 3)
+                        case["error"] = f"{type(exc).__name__}: {exc}"
+                    report["smokeTests"].append(case)
+                for tool in planned_tools:
+                    for input_name in _zip_input_names(tool):
+                        arguments = dict(tool.get("smokeTest", {}).get("input", {}))
+                        arguments[input_name] = _unsafe_zip_base64()
+                        case = {
+                            "tool": tool["name"],
+                            "case": "zip_path_traversal_rejected",
+                            "passed": False,
+                            "error": None,
+                        }
+                        try:
+                            result = await session.call_tool(tool["name"], arguments)
+                            case["passed"] = bool(result.isError)
+                            if not result.isError:
+                                case["error"] = "unsafe ZIP was accepted as a successful MCP result"
+                        except Exception as exc:
+                            case["passed"] = True
+                            case["error"] = f"rejected with {type(exc).__name__}: {exc}"
+                        report["securityTests"].append(case)
+                    for input_name in _dataset_zip_input_names(tool):
+                        arguments = dict(tool.get("smokeTest", {}).get("input", {}))
+                        arguments[input_name] = _incomplete_dataset_zip_base64()
+                        case = {
+                            "tool": tool["name"],
+                            "case": "incomplete_dataset_zip_rejected",
+                            "passed": False,
+                            "error": None,
+                        }
+                        try:
+                            result = await session.call_tool(tool["name"], arguments)
+                            case["passed"] = bool(result.isError)
+                            if not result.isError:
+                                case["error"] = (
+                                    "incomplete dataset was returned as MCP success: "
+                                    + _content_text(result)[:500]
+                                )
+                        except Exception as exc:
+                            case["passed"] = True
+                            case["error"] = f"rejected with {type(exc).__name__}: {exc}"
+                        report["securityTests"].append(case)
+    except Exception as exc:
+        report["connectionError"] = f"{type(exc).__name__}: {exc}"
+
+    smoke_count = len(report["smokeTests"])
+    smoke_passed = sum(1 for case in report["smokeTests"] if case["passed"])
+    report["smokeTestCount"] = smoke_count
+    report["smokeTestPassed"] = smoke_passed
+    report["smokePassRate"] = round(smoke_passed / smoke_count, 4) if smoke_count else None
+    report["securityTestCount"] = len(report["securityTests"])
+    report["securityTestPassed"] = sum(1 for case in report["securityTests"] if case["passed"])
+    report["passed"] = bool(
+        report["toolDiscoveryExact"]
+        and smoke_count > 0
+        and smoke_passed == smoke_count
+        and report["securityTestPassed"] == report["securityTestCount"]
+    )
+    output = json.dumps(report, ensure_ascii=False, indent=2)
+    print(output, flush=True)
+    if args.output:
+        args.output.write_text(output + "\n", encoding="utf-8")
+    return 0 if report["passed"] else 1
+
+
+def _structured_value(result: Any, schema: dict[str, Any]) -> Any:
+    structured = result.structuredContent
+    if structured is not None:
+        if schema.get("type") == "object":
+            return structured
+        if isinstance(structured, dict) and set(structured) == {"result"}:
+            return structured["result"]
+        return structured
+    text = _content_text(result)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _content_text(result: Any) -> str:
+    return "\n".join(getattr(item, "text", "") for item in result.content if hasattr(item, "text"))
+
+
+def _preview(value: Any, max_chars: int = 500) -> Any:
+    rendered = json.dumps(value, ensure_ascii=False, default=str)
+    if len(rendered) <= max_chars:
+        return value
+    return rendered[:max_chars] + "...(truncated)"
+
+
+def _zip_input_names(tool: dict[str, Any]) -> list[str]:
+    result = []
+    properties = tool.get("inputSchema", {}).get("properties", {})
+    if not isinstance(properties, dict):
+        return result
+    for name, schema in properties.items():
+        description = str(schema.get("description", "")) if isinstance(schema, dict) else ""
+        combined = f"{name} {description}".lower()
+        if "zip" in combined and ("base64" in combined or "file" in combined):
+            result.append(name)
+    return result
+
+
+def _unsafe_zip_base64() -> str:
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr("../../escape.txt", "blocked")
+    return base64.b64encode(stream.getvalue()).decode("ascii")
+
+
+def _dataset_zip_input_names(tool: dict[str, Any]) -> list[str]:
+    return [
+        name
+        for name in _zip_input_names(tool)
+        if "dataset" in name.lower()
+        or "数据集" in str(tool.get("inputSchema", {}).get("properties", {}).get(name, {}).get("description", ""))
+    ]
+
+
+def _incomplete_dataset_zip_base64() -> str:
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr("meta.yaml", "dataset_name: intentionally_incomplete\n")
+    return base64.b64encode(stream.getvalue()).decode("ascii")
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_agentic_packaging.py
+++ b/tests/test_agentic_packaging.py
@@ -1,0 +1,640 @@
+"""Contract tests for the Agent-based MCP packaging pipeline."""
+
+from __future__ import annotations
+
+import json
+import base64
+import io
+import zipfile
+from pathlib import Path
+
+from micro_agent.core.schema import AgentEvent
+from micro_agent.packaging.analyzer import RepositoryAnalyzer
+from micro_agent.packaging.models import PackagingPlan, PlanValidationError
+from micro_agent.packaging.scaffold import prepare_artifact
+from micro_agent.packaging.runtime_guardrails import decode_safe_zip
+from micro_agent.packaging.tools import PlanStore, SavePackagingPlan, SavePackagingPlanJson
+from micro_agent.packaging.verifier import ArtifactVerifier
+from micro_agent.packaging.workflow import AgenticPackagingWorkflow, AnalysisCache
+from api.services.files import extract_zip
+from fastapi import HTTPException
+
+
+def _sample_project(root: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    (project / "README.md").write_text(
+        "# Risk model\nUse predict for scoring and evaluate for labelled batches.\n",
+        encoding="utf-8",
+    )
+    (project / "requirements.txt").write_text("numpy>=1.26\n", encoding="utf-8")
+    (project / "core.py").write_text(
+        '"""Small algorithm used by the packaging contract tests."""\n\n'
+        'def _normalize(value: float) -> float:\n'
+        '    return max(0.0, min(1.0, value))\n\n'
+        'def predict(value: float) -> dict[str, float]:\n'
+        '    """Score one observation."""\n'
+        '    return {"score": _normalize(value)}\n\n'
+        'def evaluate(values: list[float]) -> dict[str, float]:\n'
+        '    """Calculate an average score."""\n'
+        '    scores = [predict(value)["score"] for value in values]\n'
+        '    return {"mean": sum(scores) / len(scores)}\n',
+        encoding="utf-8",
+    )
+    tests = project / "tests"
+    tests.mkdir()
+    (tests / "test_core.py").write_text(
+        "from core import predict\n\ndef test_predict():\n    assert predict(0.5)['score'] == 0.5\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def _plan(ir) -> PackagingPlan:
+    return PackagingPlan.validate(
+        {
+            "schemaVersion": "ioeb.agentic-mcp-plan/v1",
+            "decision": "package",
+            "analysisSummary": "仓库提供单条预测与批量评估两种稳定的用户能力。",
+            "rejectionReasons": [],
+            "services": [
+                {
+                    "id": "risk_scoring",
+                    "name": "Risk scoring",
+                    "description": "Score observations and evaluate batches.",
+                    "rationale": "Both operations share the same scoring semantics and dependencies.",
+                    "tools": [
+                        {
+                            "name": "predict_risk",
+                            "description": "Predict a normalized risk score for one value.",
+                            "sourceSymbols": ["core.predict"],
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"value": {"type": "number"}},
+                                "required": ["value"],
+                            },
+                            "outputSchema": {
+                                "type": "object",
+                                "properties": {"score": {"type": "number"}},
+                                "required": ["score"],
+                            },
+                            "adapterStrategy": "Validate a finite number and call core.predict directly.",
+                            "dependsOn": [],
+                            "smokeTest": {
+                                "enabled": True,
+                                "input": {"value": 0.5},
+                                "evidence": ["tests/test_core.py:4"],
+                            },
+                            "evidence": ["README.md:2", "core.py:6", "tests/test_core.py:3"],
+                        },
+                        {
+                            "name": "evaluate_risk",
+                            "description": "Evaluate the mean score for a batch of values.",
+                            "sourceSymbols": ["core.evaluate", "core.predict"],
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"values": {"type": "array", "items": {"type": "number"}}},
+                                "required": ["values"],
+                            },
+                            "outputSchema": {
+                                "type": "object",
+                                "properties": {"mean": {"type": "number"}},
+                                "required": ["mean"],
+                            },
+                            "adapterStrategy": "Validate a non-empty batch and delegate to core.evaluate.",
+                            "dependsOn": ["predict_risk"],
+                            "smokeTest": {
+                                "enabled": True,
+                                "input": {"values": [0.2, 0.8]},
+                                "evidence": ["README.md:2"],
+                            },
+                            "evidence": ["README.md:2", "core.py:10"],
+                        },
+                    ],
+                }
+            ],
+            "excludedSymbols": [{"symbol": "core._normalize", "reason": "internal helper"}],
+            "assumptions": [],
+            "riskNotes": [],
+        },
+        known_symbols=ir.known_symbols,
+    )
+
+
+def _valid_server() -> str:
+    return '''from mcp.server.fastmcp import FastMCP
+from adapters import evaluate_risk as evaluate
+from adapters import predict_risk as predict
+
+mcp = FastMCP("Risk scoring", host="0.0.0.0", port=8000, sse_path="/sse", message_path="/messages/")
+
+@mcp.tool()
+def predict_risk(value: float) -> dict[str, float]:
+    """Predict a normalized risk score for one value."""
+    return predict(value)
+
+@mcp.tool()
+def evaluate_risk(values: list[float]) -> dict[str, float]:
+    """Evaluate the mean score for a batch of values."""
+    return evaluate(values)
+
+starlette_app = mcp.sse_app()
+'''
+
+
+def _valid_adapters() -> str:
+    return '''from algorithm.core import evaluate as algorithm_evaluate
+from algorithm.core import predict as algorithm_predict
+
+def predict_risk(value: float) -> dict[str, float]:
+    if not isinstance(value, (int, float)):
+        raise ValueError("value must be numeric")
+    return algorithm_predict(float(value))
+
+def evaluate_risk(values: list[float]) -> dict[str, float]:
+    if not values:
+        raise ValueError("values must not be empty")
+    return algorithm_evaluate([float(value) for value in values])
+'''
+
+
+def test_repository_analyzer_scans_nested_symbols_and_evidence(tmp_path):
+    project = _sample_project(tmp_path)
+    ir = RepositoryAnalyzer().analyze(project)
+
+    assert {"core.predict", "core.evaluate", "core._normalize"} <= ir.known_symbols
+    assert ir.testFiles == ["tests/test_core.py"]
+    assert "README.md" in ir.documentation
+    assert len(ir.fingerprint) == 64
+
+
+def test_plan_generates_multi_tool_legacy_graph(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    plan = _plan(ir)
+    graph = plan.to_frontend_graph()
+
+    assert [node["label"] for node in graph["nodes"]] == ["predict_risk", "evaluate_risk"]
+    assert graph["edges"] == [{"sourceID": "9001", "targetID": "9002"}]
+    assert graph["meta"] == {
+        "schemaVersion": "ioeb.agentic-mcp-plan/v1",
+        "engine": "agentic",
+        "serviceCount": 1,
+        "toolCount": 2,
+        "analysisSummary": "仓库提供单条预测与批量评估两种稳定的用户能力。",
+    }
+
+
+def test_plan_rejects_unknown_source_symbol(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["tools"][0]["sourceSymbols"] = ["missing.predict"]
+
+    try:
+        PackagingPlan.validate(raw, known_symbols=ir.known_symbols)
+    except PlanValidationError as exc:
+        assert "未知符号" in str(exc)
+    else:
+        raise AssertionError("unknown source symbol should fail validation")
+
+
+def test_plan_rejects_server_paths_and_duplicate_semantic_tools(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["tools"][0]["inputSchema"]["properties"]["data_path"] = {"type": "string"}
+    duplicate = json.loads(json.dumps(raw["services"][0]["tools"][0]))
+    duplicate["name"] = "predict_risk_copy"
+    raw["services"][0]["tools"].append(duplicate)
+
+    try:
+        PackagingPlan.validate(raw, known_symbols=ir.known_symbols)
+    except PlanValidationError as exc:
+        assert "容器文件系统" in str(exc)
+        assert "完全相同" in str(exc)
+    else:
+        raise AssertionError("server path and duplicate surface should fail validation")
+
+
+def test_plan_rejects_insufficient_direct_source_parameters(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["tools"][1]["sourceSymbols"] = ["core.evaluate"]
+    raw["services"][0]["tools"][1]["inputSchema"] = {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+
+    try:
+        PackagingPlan.validate(
+            raw,
+            known_symbols=ir.known_symbols,
+            symbol_required_parameters={
+                symbol.qualifiedName: symbol.requiredParameters for symbol in ir.symbols
+            },
+        )
+    except PlanValidationError as exc:
+        assert "源码必填参数" in str(exc)
+    else:
+        raise AssertionError("missing direct source parameters should fail validation")
+
+
+def test_plan_rejects_excluding_independent_user_capability(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["tools"] = [raw["services"][0]["tools"][0]]
+    raw["excludedSymbols"].append(
+        {"symbol": "core.evaluate", "reason": "Non-core function that may be supported later."}
+    )
+
+    try:
+        PackagingPlan.validate(
+            raw,
+            known_symbols=ir.known_symbols,
+            candidate_symbols={"core.predict", "core.evaluate"},
+            symbol_calls={symbol.qualifiedName: symbol.calls for symbol in ir.symbols},
+        )
+    except PlanValidationError as exc:
+        assert "独立预测/计算能力" in str(exc)
+        assert "core.evaluate" in str(exc)
+    else:
+        raise AssertionError("independent application capability should not be silently excluded")
+
+
+def test_plan_requires_array_output_for_generator_source(tmp_path):
+    project = _sample_project(tmp_path)
+    core = project / "core.py"
+    core.write_text(
+        core.read_text(encoding="utf-8")
+        + "\ndef predict_many(values: list[float]):\n"
+        + "    for value in values:\n"
+        + "        yield predict(value)\n",
+        encoding="utf-8",
+    )
+    ir = RepositoryAnalyzer().analyze(project)
+    generator = next(symbol for symbol in ir.symbols if symbol.qualifiedName == "core.predict_many")
+    assert generator.isGenerator
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["tools"][1]["sourceSymbols"] = ["core.predict_many"]
+
+    try:
+        PackagingPlan.validate(
+            raw,
+            known_symbols=ir.known_symbols,
+            symbol_is_generator={symbol.qualifiedName: symbol.isGenerator for symbol in ir.symbols},
+        )
+    except PlanValidationError as exc:
+        assert "使用 yield" in str(exc)
+    else:
+        raise AssertionError("generator source must expose an array output contract")
+
+
+async def test_save_plan_tool_persists_only_valid_plan(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    store = PlanStore(tmp_path / "plan.json", ir.known_symbols)
+    tool = SavePackagingPlan(store)
+
+    raw = _plan(ir).to_dict()
+    raw["services"] = json.dumps(raw["services"], ensure_ascii=False)
+    result = await tool.execute(**raw)
+
+    assert not result.error
+    assert store.plan is not None
+    assert json.loads(store.path.read_text(encoding="utf-8"))["decision"] == "package"
+
+
+async def test_save_plan_tool_normalizes_python_like_model_arguments(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    store = PlanStore(tmp_path / "plan.json", ir.known_symbols)
+    tool = SavePackagingPlan(store)
+    raw = _plan(ir).to_dict()
+    raw["services"] = repr(raw["services"]).replace("True", "true").replace("False", "false")
+    raw["assumptions"] = "\n1. First assumption\n2. Second assumption\n"
+
+    result = await tool.execute(**raw)
+
+    assert not result.error
+    assert store.plan is not None
+    assert store.plan.data["assumptions"] == ["First assumption", "Second assumption"]
+
+
+async def test_save_plan_json_fallback_uses_same_validation(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    store = PlanStore(tmp_path / "plan.json", ir.known_symbols)
+    tool = SavePackagingPlanJson(store)
+
+    result = await tool.execute(content=json.dumps(_plan(ir).to_dict(), ensure_ascii=False))
+
+    assert not result.error
+    assert store.plan is not None
+    assert store.plan.tool_names == ["predict_risk", "evaluate_risk"]
+
+
+async def test_save_plan_json_canonicalizes_only_nonsemantic_fields(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    store = PlanStore(tmp_path / "plan.json", ir.known_symbols)
+    tool = SavePackagingPlanJson(store)
+    raw = _plan(ir).to_dict()
+    raw["services"][0].pop("id")
+    for item in raw["services"][0]["tools"]:
+        item.pop("evidence")
+        item["smokeTest"]["evidence"] = item["smokeTest"]["evidence"][0]
+
+    result = await tool.execute(content=json.dumps(raw, ensure_ascii=False))
+
+    assert not result.error
+    assert store.plan is not None
+    assert store.plan.data["services"][0]["id"] == "risk_scoring"
+    assert store.plan.tools[0]["evidence"] == ["core.predict"]
+    assert isinstance(store.plan.tools[0]["smokeTest"]["evidence"], list)
+
+
+def test_plan_rejects_operational_metadata_as_algorithm_tool(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["tools"][0]["name"] = "get_model_info"
+
+    try:
+        PackagingPlan.validate(raw, known_symbols=ir.known_symbols)
+    except PlanValidationError as exc:
+        assert "不是用户算法能力" in str(exc)
+    else:
+        raise AssertionError("operational metadata must not be exposed as an algorithm tool")
+
+
+def test_scaffold_and_verifier_accept_exact_multi_tool_contract(tmp_path):
+    project = _sample_project(tmp_path)
+    ir = RepositoryAnalyzer().analyze(project)
+    plan = _plan(ir)
+    artifact = prepare_artifact(project, tmp_path / "artifact", plan)
+    (artifact / "server.py").write_text(_valid_server(), encoding="utf-8")
+    (artifact / "adapters.py").write_text(_valid_adapters(), encoding="utf-8")
+
+    report = ArtifactVerifier(artifact, plan).verify()
+
+    assert report.passed, report.to_json()
+    assert report.checks["registeredTools"] == ["evaluate_risk", "predict_risk"]
+    assert '"FROM' not in (artifact / "Dockerfile").read_text(encoding="utf-8")
+
+
+def test_verifier_blocks_incomplete_agent_output(tmp_path):
+    project = _sample_project(tmp_path)
+    ir = RepositoryAnalyzer().analyze(project)
+    plan = _plan(ir)
+    artifact = prepare_artifact(project, tmp_path / "artifact", plan)
+    (artifact / "server.py").write_text(
+        _valid_server().replace("@mcp.tool()\ndef evaluate_risk", "def evaluate_risk"),
+        encoding="utf-8",
+    )
+    (artifact / "adapters.py").write_text(_valid_adapters(), encoding="utf-8")
+
+    report = ArtifactVerifier(artifact, plan).verify()
+
+    assert not report.passed
+    assert any("evaluate_risk" in error and "缺少" in error for error in report.errors)
+    assert not (artifact / ".ioeb-ready").exists()
+
+
+def test_runtime_zip_guardrail_accepts_safe_and_rejects_traversal():
+    safe = io.BytesIO()
+    with zipfile.ZipFile(safe, "w") as archive:
+        archive.writestr("dataset/meta.yaml", "dataset_name: demo")
+    decoded = decode_safe_zip(base64.b64encode(safe.getvalue()).decode("ascii"))
+    assert zipfile.is_zipfile(decoded)
+
+    unsafe = io.BytesIO()
+    with zipfile.ZipFile(unsafe, "w") as archive:
+        archive.writestr("../../escape.txt", "bad")
+    try:
+        decode_safe_zip(base64.b64encode(unsafe.getvalue()).decode("ascii"))
+    except ValueError as exc:
+        assert "unsafe ZIP member" in str(exc)
+    else:
+        raise AssertionError("path traversal ZIP should be rejected")
+
+
+def test_uploaded_repository_zip_extraction_is_path_contained(tmp_path):
+    safe_zip = tmp_path / "safe.zip"
+    with zipfile.ZipFile(safe_zip, "w") as archive:
+        archive.writestr("repo/main.py", "print('safe')")
+    extracted = extract_zip(safe_zip, tmp_path / "safe-out")
+    assert (extracted / "repo/main.py").read_text(encoding="utf-8") == "print('safe')"
+
+    unsafe_zip = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(unsafe_zip, "w") as archive:
+        archive.writestr("../../escaped.py", "bad")
+    try:
+        extract_zip(unsafe_zip, tmp_path / "unsafe-out")
+    except HTTPException as exc:
+        assert exc.status_code == 400
+        assert "不安全路径" in str(exc.detail)
+    else:
+        raise AssertionError("uploaded traversal ZIP should be rejected")
+    assert not (tmp_path / "escaped.py").exists()
+
+
+def test_verifier_rejects_import_shadowing_and_failure_as_success(tmp_path):
+    project = _sample_project(tmp_path)
+    ir = RepositoryAnalyzer().analyze(project)
+    plan = _plan(ir)
+    artifact = prepare_artifact(project, tmp_path / "artifact", plan)
+    (artifact / "server.py").write_text(_valid_server(), encoding="utf-8")
+    (artifact / "adapters.py").write_text(
+        '''from algorithm.core import predict as predict_risk
+from algorithm.core import evaluate as evaluate_risk
+
+def predict_risk(value: float) -> dict[str, float]:
+    try:
+        return {"score": predict_risk(value)}
+    except Exception as exc:
+        return {"score": -1.0}
+
+def evaluate_risk(values: list[float]) -> dict[str, float]:
+    return evaluate_risk(values)
+''',
+        encoding="utf-8",
+    )
+
+    report = ArtifactVerifier(artifact, plan).verify()
+
+    assert not report.passed
+    assert any("伪装成成功" in error for error in report.errors)
+    assert any("递归调用" in error for error in report.errors)
+
+
+def test_verifier_requires_guard_on_source_failure_sentinel(tmp_path):
+    project = _sample_project(tmp_path)
+    core = project / "core.py"
+    core.write_text(
+        core.read_text(encoding="utf-8")
+        + '\ndef fragile(value: float) -> dict[str, float] | str:\n'
+        + '    try:\n'
+        + '        return {"score": float(value)}\n'
+        + '    except Exception as exc:\n'
+        + '        return f"error: {exc}"\n\n'
+        + 'def run_fragile(value: float) -> dict[str, float] | str:\n'
+        + '    return fragile(value)\n',
+        encoding="utf-8",
+    )
+    ir = RepositoryAnalyzer().analyze(project)
+    fragile = next(symbol for symbol in ir.symbols if symbol.qualifiedName == "core.fragile")
+    assert fragile.failureReturns == ["error:"]
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["tools"][0]["sourceSymbols"] = ["core.run_fragile"]
+    plan = PackagingPlan.validate(raw, known_symbols=ir.known_symbols)
+    artifact = prepare_artifact(project, tmp_path / "artifact", plan)
+    (artifact / "server.py").write_text(_valid_server(), encoding="utf-8")
+    unguarded = _valid_adapters().replace(
+        "from algorithm.core import predict as algorithm_predict",
+        "from algorithm.core import run_fragile as algorithm_predict",
+    )
+    (artifact / "adapters.py").write_text(unguarded, encoding="utf-8")
+
+    report = ArtifactVerifier(artifact, plan).verify()
+
+    assert not report.passed
+    assert any("返回值并 raise" in error for error in report.errors)
+
+    guarded = unguarded.replace(
+        "    return algorithm_predict(float(value))",
+        '    result = algorithm_predict(float(value))\n'
+        '    if isinstance(result, str) and result.lower().startswith("error"):\n'
+        '        raise RuntimeError(result)\n'
+        '    return result',
+    )
+    (artifact / "adapters.py").write_text(guarded, encoding="utf-8")
+
+    fixed_report = ArtifactVerifier(artifact, plan).verify()
+
+    assert fixed_report.passed, fixed_report.to_json()
+
+
+def test_verifier_rejects_legacy_import_before_loader_and_wrong_asset_root(tmp_path):
+    project = _sample_project(tmp_path)
+    (project / "risk-model.bin").write_bytes(b"model")
+    ir = RepositoryAnalyzer().analyze(project)
+    plan = _plan(ir)
+    artifact = prepare_artifact(project, tmp_path / "artifact", plan)
+    (artifact / "server.py").write_text(_valid_server(), encoding="utf-8")
+    (artifact / "adapters.py").write_text(
+        '''from pathlib import Path
+from core import evaluate as algorithm_evaluate
+from core import predict as algorithm_predict
+from algorithm_loader import ALGORITHM_DIR
+
+MODEL_PATH = Path(__file__).resolve().parent / "risk-model.bin"
+
+def predict_risk(value: float) -> dict[str, float]:
+    return algorithm_predict(value)
+
+def evaluate_risk(values: list[float]) -> dict[str, float]:
+    return algorithm_evaluate(values)
+''',
+        encoding="utf-8",
+    )
+
+    report = ArtifactVerifier(artifact, plan).verify()
+
+    assert not report.passed
+    assert any("源码模块导入前" in error for error in report.errors)
+    assert any("risk-model.bin" in error and "ALGORITHM_DIR" in error for error in report.errors)
+
+
+def test_verifier_requires_direct_single_base64_zip_guard(tmp_path):
+    project = _sample_project(tmp_path)
+    ir = RepositoryAnalyzer().analyze(project)
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["tools"][0]["inputSchema"] = {
+        "type": "object",
+        "properties": {
+            "zip_file_data": {
+                "type": "string",
+                "description": "Base64 encoded ZIP file",
+            }
+        },
+        "required": ["zip_file_data"],
+    }
+    raw["services"][0]["tools"][0]["smokeTest"] = {
+        "enabled": False,
+        "rationale": "The unit test only exercises the generated guardrail contract.",
+    }
+    plan = PackagingPlan.validate(raw, known_symbols=ir.known_symbols)
+    artifact = prepare_artifact(project, tmp_path / "artifact", plan)
+    (artifact / "adapters.py").write_text(
+        '''import base64
+from algorithm.core import evaluate as algorithm_evaluate
+from algorithm.core import predict as algorithm_predict
+from runtime_guardrails import decode_safe_zip
+
+def predict_risk(zip_file_data: str) -> dict[str, float]:
+    stream = decode_safe_zip(base64.b64decode(zip_file_data))
+    return {"score": float(len(stream.read()))}
+
+def evaluate_risk(values: list[float]) -> dict[str, float]:
+    return algorithm_evaluate(values)
+''',
+        encoding="utf-8",
+    )
+
+    report = ArtifactVerifier(artifact, plan).verify()
+
+    assert not report.passed
+    assert any("直接传给" in error for error in report.errors)
+    assert any("重复 Base64 解码" in error for error in report.errors)
+
+
+def test_analysis_cache_is_content_addressed_and_immutable(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    plan = _plan(ir)
+    cache = AnalysisCache(max_entries=2, ttl_seconds=60)
+    cache.put(ir.fingerprint, plan)
+
+    loaded = cache.get(ir.fingerprint)
+    assert loaded is not None
+    loaded.data["services"][0]["tools"][0]["name"] = "mutated"
+    assert cache.get(ir.fingerprint).tool_names[0] == "predict_risk"
+
+
+async def test_packaging_workflow_repairs_then_marks_artifact_ready(tmp_path, monkeypatch):
+    project = _sample_project(tmp_path)
+    ir = RepositoryAnalyzer().analyze(project)
+    plan = _plan(ir)
+    artifact = tmp_path / "artifact"
+
+    class FakeBuilder:
+        max_steps = 2
+
+        def __init__(self):
+            self.calls = 0
+
+        def cancel(self):
+            pass
+
+        async def run(self, prompt):
+            self.calls += 1
+            if self.calls == 1:
+                (artifact / "server.py").write_text("def broken(:\n", encoding="utf-8")
+                (artifact / "adapters.py").write_text(_valid_adapters(), encoding="utf-8")
+            else:
+                (artifact / "server.py").write_text(_valid_server(), encoding="utf-8")
+            yield AgentEvent(type="done", step=1, data={"result": "attempt complete"})
+
+    fake_builder = FakeBuilder()
+    monkeypatch.setattr(
+        "micro_agent.packaging.workflow._build_builder_agent",
+        lambda *args, **kwargs: fake_builder,
+    )
+    workflow = AgenticPackagingWorkflow(
+        project_dir=project,
+        ir=ir,
+        artifact_dir=artifact,
+        plan=plan,
+        max_repairs=2,
+    )
+
+    events = [event async for event in workflow.run("package it")]
+
+    assert fake_builder.calls == 2
+    assert events[-1].type == "done"
+    marker = json.loads((artifact / ".ioeb-ready").read_text(encoding="utf-8"))
+    assert marker["toolCount"] == 2
+    assert marker["repairAttempts"] == 1


### PR DESCRIPTION
## What changed

- Replaced the deterministic/template packaging path with a two-stage Agent workflow:
  - repository-wide semantic planning for services and MCP tools
  - Agent implementation of adapters followed by deterministic verification and bounded repair
- Preserved the existing frontend API/SSE contracts for `code_analysis` and `service_packaging`.
- Added strict plan, artifact, source-boundary, ZIP, path, schema, and failure-as-success guardrails.
- Added reproducible offline packaging and running MCP protocol validation scripts.
- Hardened uploaded ZIP extraction against traversal, symlinks, archive bombs, and oversized archives.

## Why

The reverted implementation mechanically wrapped template entrypoints and could report packaging/deployment success without performing interface abstraction, service/tool planning, or runtime failure detection. The new flow restores Agent-based reasoning over the whole repository while keeping deterministic acceptance gates around the generated artifact.

## Validation

- `114 passed` locally.
- AML: 3/3 planned tools discovered and 3/3 smoke calls passed.
- Linezolid: 1/1 tool discovered and 1/1 smoke call passed.
- GNN: 1/1 tool discovered; malicious traversal ZIP and incomplete dataset ZIP both rejected. Positive inference remains explicitly unmeasured because the submitted repository has no real dataset fixture.
- VPN validation used isolated `/tmp` artifacts/containers only; no online or staging environment was manually updated.
