### PR TITLE
fix: install OpenRouter JSON runtime dependency

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip install --no-cache-dir -e ".[all]"
+RUN pip install --no-cache-dir -e ".[all]" \
+    && python -c "import orjson"
 
 EXPOSE 8010 22 8000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "litellm>=1.50.0",
+    "orjson>=3.11.6,<4.0",
     "loguru>=0.7.0",
     "httpx>=0.27.0",
     "jinja2>=3.1.0",


### PR DESCRIPTION
## Root cause

The deployed Micro-Agent image installs base LiteLLM, while LiteLLM declares `orjson` only in its proxy extra. The OpenRouter request/error-processing path can import that optional module dynamically, so repository analysis failed before the packaging Agent started.

## Fix

- Add the compatible `orjson>=3.11.6,<4.0` runtime dependency.
- Make the production image build fail immediately if `orjson` cannot be imported.

## Validation

- Fresh Python 3.12 `.[all]` installation resolves LiteLLM 1.92.0 and orjson 3.11.9.
- orjson serialization round trip succeeds.
- Full test suite: 114 passed.
