### PR TITLE
fix: use reliable package index for MCP images

### DIFF
--- a/micro_agent/packaging/scaffold.py
+++ b/micro_agent/packaging/scaffold.py
@@ -48,10 +48,12 @@ def prepare_artifact(project_dir: str | Path, artifact_dir: str | Path, plan: Pa
     compose_name = re.sub(r"[^a-z0-9_-]", "-", service_id.lower()).strip("-") or "mcp-service"
     (output_root / "Dockerfile").write_text(
         "FROM python:3.11-slim\n"
+        "ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple\n"
         "ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1\n"
         "WORKDIR /app\n"
         "COPY requirements.txt /app/requirements.txt\n"
-        "RUN pip install --no-cache-dir -r /app/requirements.txt\n"
+        "RUN pip install --no-cache-dir --index-url \"${PIP_INDEX_URL}\" "
+        "--timeout 120 --retries 5 -r /app/requirements.txt\n"
         "COPY . /app\n"
         "EXPOSE 8000\n"
         "CMD [\"python\", \"server.py\"]\n",

--- a/tests/test_agentic_packaging.py
+++ b/tests/test_agentic_packaging.py
@@ -373,7 +373,10 @@ def test_scaffold_and_verifier_accept_exact_multi_tool_contract(tmp_path):
 
     assert report.passed, report.to_json()
     assert report.checks["registeredTools"] == ["evaluate_risk", "predict_risk"]
-    assert '"FROM' not in (artifact / "Dockerfile").read_text(encoding="utf-8")
+    dockerfile = (artifact / "Dockerfile").read_text(encoding="utf-8")
+    assert '"FROM' not in dockerfile
+    assert "PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple" in dockerfile
+    assert '--index-url "${PIP_INDEX_URL}" --timeout 120 --retries 5' in dockerfile
 
 
 def test_verifier_blocks_incomplete_agent_output(tmp_path):


### PR DESCRIPTION
## What changed
- generated MCP Dockerfiles now use Tsinghua PyPI by default
- the index remains configurable through the PIP_INDEX_URL build argument
- pip build retries and timeouts are explicit

## Why
The deployment host cannot reliably reach the official PyPI index, so generated images failed during dependency installation even though package resolution itself was valid.

## Validation
- full test suite: 114 passed
- focused Agentic packaging tests: 22 passed