### PR TITLE
chore: use official OpenRouter Qwen 3.6 Flash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # LLM 配置（优先级高于 config/default.toml）
-LLM_MODEL=deepseek/deepseek-chat
+LLM_MODEL=openrouter/qwen/qwen3.6-flash
 LLM_API_KEY=your-api-key-here
-LLM_BASE_URL=
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_REASONING_ENABLED=false
 LLM_TEMPERATURE=0.0
 LLM_MAX_TOKENS=8192
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update \
 
 WORKDIR /app
 
+ENV LLM_MODEL="openrouter/qwen/qwen3.6-flash" \
+    LLM_BASE_URL="https://openrouter.ai/api/v1" \
+    LLM_REASONING_ENABLED="false"
+
 COPY pyproject.toml ./
 RUN pip install --no-cache-dir ".[all]" 2>/dev/null || true
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ cp .env.example .env
 编辑 `.env`，填入 API Key：
 
 ```bash
-LLM_MODEL=deepseek/deepseek-chat
+LLM_MODEL=openrouter/qwen/qwen3.6-flash
 LLM_API_KEY=sk-xxx
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_REASONING_ENABLED=false
 ```
 
-> 支持任何 [litellm 兼容的模型格式](https://docs.litellm.ai/docs/providers)，如 `openai/gpt-4o`、`ollama/qwen2.5`、`openrouter/qwen/qwen3-coder-flash` 等。
+> 支持任何 [litellm 兼容的模型格式](https://docs.litellm.ai/docs/providers)，如 `openai/gpt-4o`、`ollama/qwen2.5`、`openrouter/qwen/qwen3.6-flash` 等。
 
 ### 启动
 

--- a/README_en.md
+++ b/README_en.md
@@ -79,11 +79,13 @@ cp .env.example .env
 Edit `.env` and fill in your API key:
 
 ```bash
-LLM_MODEL=deepseek/deepseek-chat
+LLM_MODEL=openrouter/qwen/qwen3.6-flash
 LLM_API_KEY=sk-xxx
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_REASONING_ENABLED=false
 ```
 
-> Any [litellm-compatible model format](https://docs.litellm.ai/docs/providers) is supported, e.g. `openai/gpt-4o`, `ollama/qwen2.5`, `openrouter/qwen/qwen3-coder-flash`, etc.
+> Any [litellm-compatible model format](https://docs.litellm.ai/docs/providers) is supported, e.g. `openai/gpt-4o`, `ollama/qwen2.5`, `openrouter/qwen/qwen3.6-flash`, etc.
 
 ### Launch
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -2,25 +2,31 @@
 # 用法: config.get_llm("fast") / build_agent(..., llm_profile="fast")
 
 [llm.default]
-model = "openrouter/qwen/qwen3-coder-flash"
+model = "openrouter/qwen/qwen3.6-flash"
+base_url = "https://openrouter.ai/api/v1"
 temperature = 0.0
 max_tokens = 8192
 timeout = 60
 num_retries = 3
+reasoning_enabled = false
 
 [llm.fast]
-model = "openrouter/qwen/qwen3-coder-flash"
+model = "openrouter/qwen/qwen3.6-flash"
+base_url = "https://openrouter.ai/api/v1"
 temperature = 0.0
 max_tokens = 4096
 timeout = 30
 num_retries = 2
+reasoning_enabled = false
 
 [llm.reasoning]
-model = "openrouter/qwen/qwen3-coder-flash"
+model = "openrouter/qwen/qwen3.6-flash"
+base_url = "https://openrouter.ai/api/v1"
 temperature = 0.0
 max_tokens = 16384
 timeout = 120
 num_retries = 3
+reasoning_enabled = false
 
 [agent]
 max_steps = 30

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,6 +16,13 @@ RUN mkdir -p /var/run/sshd \
 
 WORKDIR /app
 
+# Public runtime defaults. Compose/environment values can still override these.
+# Keeping them in the image prevents legacy mounted config files from silently
+# overriding the selected OpenRouter endpoint.
+ENV LLM_MODEL="openrouter/qwen/qwen3.6-flash" \
+    LLM_BASE_URL="https://openrouter.ai/api/v1" \
+    LLM_REASONING_ENABLED="false"
+
 COPY . /app
 
 RUN pip install --no-cache-dir -e ".[all]" \

--- a/micro_agent/core/config.py
+++ b/micro_agent/core/config.py
@@ -28,6 +28,7 @@ class LLMConfig:
     max_tokens: int = 8192
     timeout: int = 60
     num_retries: int = 3
+    reasoning_enabled: Optional[bool] = None
 
 
 @dataclass
@@ -113,6 +114,12 @@ class AppConfig:
         _apply_env(cfg.llm, "base_url", "LLM_BASE_URL")
         _apply_env(cfg.llm, "temperature", "LLM_TEMPERATURE", float)
         _apply_env(cfg.llm, "max_tokens", "LLM_MAX_TOKENS", int)
+        _apply_env(
+            cfg.llm,
+            "reasoning_enabled",
+            "LLM_REASONING_ENABLED",
+            _parse_bool,
+        )
         _apply_env(cfg.agent, "max_steps", "AGENT_MAX_STEPS", int)
         _apply_env(cfg.platform, "ioeb_api_base_url", "IOEB_API_BASE_URL")
         _apply_env(cfg.platform, "request_timeout", "IOEB_REQUEST_TIMEOUT", float)
@@ -137,6 +144,15 @@ def _apply_dict(obj: object, d: dict) -> None:
     for k, v in d.items():
         if hasattr(obj, k):
             setattr(obj, k, v)
+
+
+def _parse_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"无效布尔值: {value}")
 
 
 def _apply_env(

--- a/micro_agent/core/llm.py
+++ b/micro_agent/core/llm.py
@@ -32,6 +32,7 @@ class LLM:
         self.max_tokens = cfg.max_tokens
         self.timeout = cfg.timeout
         self.num_retries = cfg.num_retries
+        self.reasoning_enabled = cfg.reasoning_enabled
         self.api_key = cfg.api_key
         self.base_url = cfg.base_url
 
@@ -56,6 +57,8 @@ class LLM:
             params["api_key"] = self.api_key
         if self.base_url:
             params["api_base"] = self.base_url
+        if self.reasoning_enabled is not None:
+            params["reasoning"] = {"enabled": self.reasoning_enabled}
         if tools:
             params["tools"] = tools
             params["tool_choice"] = tool_choice

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import pytest
+
+from micro_agent.core.config import LLMConfig
+from micro_agent.core.llm import LLM
+
+
+def _completion(content: str = "ok") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=None))
+        ],
+        usage=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_complete_disables_reasoning(monkeypatch):
+    captured = {}
+
+    async def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return _completion()
+
+    monkeypatch.setattr("micro_agent.core.llm.litellm.acompletion", fake_completion)
+    llm = LLM(
+        LLMConfig(
+            model="openrouter/qwen/qwen3.6-flash",
+            base_url="https://openrouter.ai/api/v1",
+            reasoning_enabled=False,
+        )
+    )
+
+    response = await llm.complete([{"role": "user", "content": "ping"}])
+
+    assert response.content == "ok"
+    assert captured["model"] == "openrouter/qwen/qwen3.6-flash"
+    assert captured["api_base"] == "https://openrouter.ai/api/v1"
+    assert captured["reasoning"] == {"enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_complete_omits_reasoning_when_unconfigured(monkeypatch):
+    captured = {}
+
+    async def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return _completion()
+
+    monkeypatch.setattr("micro_agent.core.llm.litellm.acompletion", fake_completion)
+
+    await LLM(LLMConfig()).complete([{"role": "user", "content": "ping"}])
+
+    assert "reasoning" not in captured

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -31,7 +31,27 @@ def test_llm_profiles_multiple():
     assert "fast" in cfg.llm_profiles
     assert "reasoning" in cfg.llm_profiles
     assert cfg.llm_profiles["fast"].max_tokens == 4096
-    assert cfg.llm_profiles["reasoning"].model == "openrouter/qwen/qwen3-coder-flash"
+    reasoning = cfg.llm_profiles["reasoning"]
+    assert reasoning.model == "openrouter/qwen/qwen3.6-flash"
+    assert reasoning.base_url == "https://openrouter.ai/api/v1"
+    assert reasoning.reasoning_enabled is False
+
+
+def test_llm_reasoning_env_override(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '[llm]\nmodel = "legacy/model"\nbase_url = "http://legacy.invalid/v1"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LLM_MODEL", "openrouter/qwen/qwen3.6-flash")
+    monkeypatch.setenv("LLM_BASE_URL", "https://openrouter.ai/api/v1")
+    monkeypatch.setenv("LLM_REASONING_ENABLED", "false")
+
+    cfg = AppConfig.load(config_path)
+
+    assert cfg.llm.model == "openrouter/qwen/qwen3.6-flash"
+    assert cfg.llm.base_url == "https://openrouter.ai/api/v1"
+    assert cfg.llm.reasoning_enabled is False
 
 
 async def test_build_agent_with_profile():


### PR DESCRIPTION
## What changed

- switch the default runtime model to `qwen/qwen3.6-flash`
- route requests through the official `https://openrouter.ai/api/v1` endpoint
- explicitly send `reasoning: {"enabled": false}` through LiteLLM
- bake the public runtime defaults into the image so the existing staging-mounted legacy config cannot keep selecting the relay, while Compose environment variables can still override them
- update examples and add configuration/request parameter coverage

## Why

The staging deployment still selected an internal relay and `qwen/qwen3.5-flash-02-23`. A packaging request timed out at that relay. The selected replacement model is available on OpenRouter and should run without reasoning mode.

## Validation

- `117 passed` in the stable test suite
- direct request from the staging host to official OpenRouter succeeded with response `OK`
- returned reasoning field was `None`
- no staging or production host files were modified manually
