### PR TITLE
fix: recover misplaced agent plan exclusions

### DIFF
--- a/micro_agent/core/task.py
+++ b/micro_agent/core/task.py
@@ -102,10 +102,17 @@ class TaskManager:
 
     async def _execute(self, ctx: TaskContext, request: str) -> None:
         try:
+            terminal_error = False
             async for event in ctx._agent.run(request):
                 await ctx.add_event(event)
+                if event.type == "error":
+                    terminal_error = True
+                elif event.type == "done":
+                    # Workflows may recover from an intermediate Agent error. A
+                    # later done event is therefore the authoritative outcome.
+                    terminal_error = False
             if ctx.status == "running":
-                ctx.status = "completed"
+                ctx.status = "failed" if terminal_error else "completed"
         except asyncio.CancelledError:
             if not self._has_cancelled_event(ctx):
                 await ctx.add_event(

--- a/micro_agent/packaging/models.py
+++ b/micro_agent/packaging/models.py
@@ -89,6 +89,11 @@ class PackagingPlan:
             if not isinstance(service, dict):
                 errors.append(f"{prefix} 必须是 object")
                 continue
+            if "excludedSymbols" in service:
+                errors.append(
+                    f"{prefix}.excludedSymbols 字段层级错误；"
+                    "必须移动到规划顶层 excludedSymbols"
+                )
             service_id = service.get("id")
             if not isinstance(service_id, str) or not _SNAKE_CASE.match(service_id):
                 errors.append(f"{prefix}.id 必须是 snake_case")
@@ -584,6 +589,7 @@ PLAN_JSON_SCHEMA: dict[str, Any] = {
                     },
                 },
                 "required": ["id", "name", "description", "rationale", "tools"],
+                "additionalProperties": False,
             },
         },
         "excludedSymbols": {
@@ -601,5 +607,8 @@ PLAN_JSON_SCHEMA: dict[str, Any] = {
         "assumptions": {"type": "array", "items": {"type": "string"}},
         "riskNotes": {"type": "array", "items": {"type": "string"}},
     },
-    "required": ["schemaVersion", "decision", "analysisSummary", "services"],
+    "required": [
+        "schemaVersion", "decision", "analysisSummary", "services", "excludedSymbols",
+    ],
+    "additionalProperties": False,
 }

--- a/micro_agent/packaging/tools.py
+++ b/micro_agent/packaging/tools.py
@@ -149,6 +149,7 @@ class SavePackagingPlanJson(Tool):
     description = (
         "当复杂 services 被函数调用序列化损坏时，以一段严格 JSON 文本提交完整规划；"
         "内容仍执行与 save_packaging_plan 完全相同的所有质量门禁。"
+        "excludedSymbols 是规划根节点字段，不能放在 services 内。"
     )
     parameters = {
         "type": "object",
@@ -188,9 +189,16 @@ def _canonicalize_nonsemantic_shape(raw: dict[str, Any]) -> None:
     services = raw.get("services")
     if not isinstance(services, list):
         return
+    nested_exclusions: list[Any] = []
     for service in services:
         if not isinstance(service, dict):
             continue
+        service_exclusions = service.get("excludedSymbols")
+        if isinstance(service_exclusions, list):
+            # excludedSymbols audits the whole repository, not one logical service.
+            # Some providers nevertheless place it next to service tools. Moving a
+            # well-formed list is a structural repair and does not alter semantics.
+            nested_exclusions.extend(service.pop("excludedSymbols"))
         service_id = service.get("id")
         if (not isinstance(service_id, str) or not service_id.strip()) and isinstance(
             service.get("name"), str
@@ -211,6 +219,28 @@ def _canonicalize_nonsemantic_shape(raw: dict[str, Any]) -> None:
             smoke = tool.get("smokeTest")
             if isinstance(smoke, dict) and isinstance(smoke.get("evidence"), str):
                 smoke["evidence"] = [smoke["evidence"]]
+
+    if nested_exclusions:
+        root_exclusions = raw.get("excludedSymbols", [])
+        if isinstance(root_exclusions, list):
+            raw["excludedSymbols"] = _merge_excluded_symbols(
+                root_exclusions,
+                nested_exclusions,
+            )
+
+
+def _merge_excluded_symbols(root: list[Any], nested: list[Any]) -> list[Any]:
+    """Merge misplaced exclusions deterministically, preferring root reasons."""
+    merged: list[Any] = []
+    seen_symbols: set[str] = set()
+    for item in [*root, *nested]:
+        symbol = item.get("symbol") if isinstance(item, dict) else None
+        if isinstance(symbol, str):
+            if symbol in seen_symbols:
+                continue
+            seen_symbols.add(symbol)
+        merged.append(item)
+    return merged
 
 
 def _snake_identifier(value: str, *, fallback: str) -> str:

--- a/micro_agent/packaging/workflow.py
+++ b/micro_agent/packaging/workflow.py
@@ -48,7 +48,9 @@ PLANNER_SYSTEM_PROMPT = """你是 IOEB 的 MCP 服务架构 Agent。你的职责
 8. smokeTest 只能使用仓库中真实存在、可执行的 fixture，或从源码中明确的字段约束机械选择输入；enabled=true 时 evidence 必须引用对应仓库文件/行号。没有可追溯输入时必须 enabled=false 并写 rationale，绝不能编造 Base64、文件路径或预期输出。
 9. 每个公开函数/方法都必须可审计：被工具使用的写入 sourceSymbols，其余写入 excludedSymbols 并逐项说明为什么它只是内部实现或不适合远程调用。
    独立的 predict/infer/evaluate/calculate/score/dose 等业务能力不能只以“非核心、内部使用、未来支持”为理由排除；只有调用图证明它已被某个端到端 sourceSymbol 组合时，才可作为内部子流程。
+   excludedSymbols 必须位于规划 JSON 根节点，和 services 同级；绝不能写入 services[i] 内。
 10. 必须用 save_packaging_plan_json 提交一段无 Markdown fence 的完整严格 JSON。每次调用都是完整替换，不是局部 PATCH；校验失败后也必须重发包含非空 services 的完整规划，不能只发送修改字段。保存成功后调用 terminate。
+    顶层结构固定为 {"schemaVersion": ..., "decision": ..., "analysisSummary": ..., "services": [...], "excludedSymbols": [...], "assumptions": [...], "riskNotes": [...]}。
 """
 
 
@@ -315,6 +317,7 @@ async def _run_planner(
         prompt = _planner_prompt(ir, user_request) if attempt == 0 else (
             "你尚未提交一个有效规划。必须使用 save_packaging_plan_json 重新发送完整严格 JSON；"
             "这不是 PATCH，decision=package 时 services 绝对不能省略或为空。"
+            "excludedSymbols 必须位于 JSON 根节点并与 services 同级，不能放进任一 service。"
             + ("\n上次校验错误：\n- " + "\n- ".join(store.last_errors) if store.last_errors else "")
         )
         async for event in agent.run(prompt):

--- a/tests/test_agentic_packaging.py
+++ b/tests/test_agentic_packaging.py
@@ -348,6 +348,41 @@ async def test_save_plan_json_canonicalizes_only_nonsemantic_fields(tmp_path):
     assert isinstance(store.plan.tools[0]["smokeTest"]["evidence"], list)
 
 
+async def test_save_plan_json_recovers_service_scoped_excluded_symbols(tmp_path):
+    """Regression for the GNN plan that nested the repository audit in a service."""
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    store = PlanStore(
+        tmp_path / "plan.json",
+        ir.known_symbols,
+        candidate_symbols={"core.predict", "core.evaluate"},
+    )
+    tool = SavePackagingPlanJson(store)
+    raw = _plan(ir).to_dict()
+    expected = raw.pop("excludedSymbols")
+    raw["services"][0]["excludedSymbols"] = expected
+
+    result = await tool.execute(content=json.dumps(raw, ensure_ascii=False))
+
+    assert not result.error
+    assert store.plan is not None
+    assert store.plan.data["excludedSymbols"] == expected
+    assert "excludedSymbols" not in store.plan.data["services"][0]
+
+
+async def test_save_plan_reports_malformed_service_scoped_exclusions(tmp_path):
+    ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
+    store = PlanStore(tmp_path / "plan.json", ir.known_symbols)
+    tool = SavePackagingPlanJson(store)
+    raw = _plan(ir).to_dict()
+    raw["services"][0]["excludedSymbols"] = "not-an-array"
+
+    result = await tool.execute(content=json.dumps(raw, ensure_ascii=False))
+
+    assert result.error
+    assert "services[0].excludedSymbols 字段层级错误" in result.error
+    assert "规划顶层 excludedSymbols" in result.error
+
+
 def test_plan_rejects_operational_metadata_as_algorithm_tool(tmp_path):
     ir = RepositoryAnalyzer().analyze(_sample_project(tmp_path))
     raw = _plan(ir).to_dict()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,6 +109,50 @@ async def test_task_manager_subscribe_realtime():
     print("[PASS] TaskContext 实时订阅")
 
 
+async def test_task_manager_marks_terminal_error_as_failed():
+    """A yielded error is a failed task even when the generator exits normally."""
+    from unittest.mock import MagicMock
+
+    from micro_agent.core.agent import Agent
+    from micro_agent.core.schema import AgentEvent
+    from micro_agent.core.task import TaskManager
+
+    agent = MagicMock(spec=Agent)
+    agent.memory = None
+
+    async def fake_run(_request):
+        yield AgentEvent(type="error", step=99, data={"error": "invalid plan"})
+
+    agent.run = fake_run
+    manager = TaskManager()
+    ctx = await manager.submit(agent, "analyze", task_id="failed_plan")
+    await ctx._runner
+
+    assert ctx.status == "failed"
+
+
+async def test_task_manager_allows_recovery_after_intermediate_error():
+    from unittest.mock import MagicMock
+
+    from micro_agent.core.agent import Agent
+    from micro_agent.core.schema import AgentEvent
+    from micro_agent.core.task import TaskManager
+
+    agent = MagicMock(spec=Agent)
+    agent.memory = None
+
+    async def fake_run(_request):
+        yield AgentEvent(type="error", step=1, data={"error": "retryable"})
+        yield AgentEvent(type="done", step=2, data={"result": "recovered"})
+
+    agent.run = fake_run
+    manager = TaskManager()
+    ctx = await manager.submit(agent, "analyze", task_id="recovered_plan")
+    await ctx._runner
+
+    assert ctx.status == "completed"
+
+
 async def test_fastapi_import():
     """测试 FastAPI app 能正常导入。"""
     from api.app import app


### PR DESCRIPTION
## What changed

- normalize `services[*].excludedSymbols` into the plan-level audit list before validation
- reject malformed service-scoped exclusions with an explicit field-path error
- make the planner prompt and schema state the root-level contract directly
- mark tasks whose terminal event is `error` as failed while preserving recoverable workflows
- add regression coverage for the GNN plan shape and task status semantics

## Root cause

The GNN planning agent correctly classified 17 excluded repository symbols, but placed the list under `services[0]`. The validator silently defaulted the missing root list to empty and repeatedly reported 12 unclassified symbols, so the agent exhausted its retries without reaching packaging.

## Impact

Deterministic provider formatting mistakes are now repaired without another LLM call. Invalid shapes receive actionable feedback, and API task status reflects terminal workflow failures.

## Validation

- `python -m pytest tests/ -x -q --ignore=tests/e2e_demo.py --ignore=tests/bench_rag_quality.py` — 121 passed
- replayed the exact failed staging GNN plan through the updated validator — accepted as 1 service, 2 tools, and 17 root-level excluded symbols
- `git diff --check`
