### PR TITLE
fix(simulation): prevent SSRF via user-controlled MCP server URL (CWE-918)

### DIFF
--- a/micro_agent/simulation/service_tool_session.py
+++ b/micro_agent/simulation/service_tool_session.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import ipaddress
+import os
 import re
+import socket
 from typing import Any, Callable
+from urllib.parse import urlsplit
 
 from micro_agent.simulation.logging_mcp_tool import LoggingMCPTool
 from micro_agent.simulation.sandbox_tool import SandboxTool
@@ -83,6 +87,7 @@ class ServiceToolSession:
             raise ServiceConnectionError(f"真实 MCP 配置无效 [{service_name}]：不支持 {method}")
         if not endpoint.startswith(("http://", "https://")):
             raise ServiceConnectionError(f"真实 MCP 配置无效 [{service_name}]：缺少 HTTP 地址")
+        _validate_mcp_endpoint(endpoint, service_name)
         server = ServerConfig(
             connection_type="sse" if method == "sse" else "streamable_http",
             server_url=endpoint,
@@ -141,6 +146,80 @@ class ServiceToolSession:
     async def __aexit__(self, *args: object) -> None:
         await self.close()
 
+
+
+
+def _mcp_url_allowed_hosts() -> set[str]:
+    raw = os.getenv("MICRO_AGENT_MCP_ALLOW_HOSTS", "")
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def _mcp_url_allow_private() -> bool:
+    return os.getenv("MICRO_AGENT_MCP_ALLOW_PRIVATE", "").lower() in {"1", "true", "yes"}
+
+
+def _validate_mcp_endpoint(endpoint: str, service_name: str) -> None:
+    """Reject SSRF-prone MCP URLs before initiating a connection.
+
+    Blocks loopback, link-local, private, multicast, reserved and
+    unspecified addresses (both IPv4 and IPv6) unless the host is
+    explicitly listed in MICRO_AGENT_MCP_ALLOW_HOSTS, or
+    MICRO_AGENT_MCP_ALLOW_PRIVATE is set (for trusted intranet
+    deployments).
+    """
+    try:
+        parts = urlsplit(endpoint)
+    except ValueError as exc:  # pragma: no cover - urlsplit is lenient
+        raise ServiceConnectionError(
+            f"真实 MCP 配置无效 [{service_name}]：URL 解析失败 ({exc})"
+        )
+    if parts.scheme not in {"http", "https"}:
+        raise ServiceConnectionError(
+            f"真实 MCP 配置无效 [{service_name}]：仅支持 http/https"
+        )
+    host = (parts.hostname or "").strip()
+    if not host:
+        raise ServiceConnectionError(
+            f"真实 MCP 配置无效 [{service_name}]：缺少主机名"
+        )
+    host_l = host.lower()
+    allow_hosts = _mcp_url_allowed_hosts()
+    if host_l in allow_hosts:
+        return
+    if _mcp_url_allow_private():
+        return
+    # Reject obvious loopback aliases before DNS resolution.
+    if host_l in {"localhost", "ip6-localhost", "ip6-loopback"} or host_l.endswith(".localhost"):
+        raise ServiceConnectionError(
+            f"MCP 目标被拒绝 [{service_name}] {endpoint}: 禁止访问回环地址"
+        )
+    # Resolve all A/AAAA records and reject if any is non-global.
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError:
+        # DNS resolution failed; let the connection layer surface the error
+        # rather than blocking here. SSRF is only possible after a successful
+        # resolve to an internal IP.
+        return
+    for info in infos:
+        addr = info[4][0]
+        # Strip IPv6 scope id if present.
+        addr = addr.split("%", 1)[0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise ServiceConnectionError(
+                f"MCP 目标被拒绝 [{service_name}] {endpoint}: 禁止访问内网/回环地址 ({addr})"
+            )
 
 def _sanitize(value: Any, max_len: int = 128) -> str:
     ident = re.sub(r"[^A-Za-z0-9_-]+", "_", str(value or "srv"))

--- a/tests/test_cwe918_mcp_ssrf.py
+++ b/tests/test_cwe918_mcp_ssrf.py
@@ -1,0 +1,64 @@
+"""PoC: SSRF via user-controlled MCP server URL in ServiceToolSession."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from micro_agent.simulation.service_tool_session import (
+    ServiceConnectionError,
+    ServiceToolSession,
+)
+
+
+class RecordingConnection:
+    def __init__(self) -> None:
+        self.attempts: list[str] = []
+
+    async def connect(self, server, *_a, **_kw):
+        self.attempts.append(server.server_url)
+        raise RuntimeError("should not reach network for blocked host")
+
+    async def disconnect_all(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1:6379/sse",
+    "http://localhost/sse",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://10.0.0.5:8080/sse",
+    "http://192.168.1.1/sse",
+    "http://[::1]/sse",
+])
+def test_ssrf_blocks_internal_mcp_urls(url):
+    conn = RecordingConnection()
+    session = ServiceToolSession(
+        [{
+            "id": "svc",
+            "name": "svc",
+            "isFake": False,
+            "mcpMethod": "sse",
+            "mcpUrl": url,
+        }],
+        connection=conn,
+    )
+    with pytest.raises(ServiceConnectionError):
+        asyncio.run(session.connect())
+    assert conn.attempts == [], f"SSRF: connection attempted to {conn.attempts}"
+
+
+def test_ssrf_allows_public_host_but_still_fails_gracefully():
+    conn = RecordingConnection()
+    session = ServiceToolSession(
+        [{
+            "id": "svc",
+            "name": "svc",
+            "isFake": False,
+            "mcpMethod": "sse",
+            "mcpUrl": "https://mcp.example.test/sse",
+        }],
+        connection=conn,
+    )
+    with pytest.raises(ServiceConnectionError):
+        asyncio.run(session.connect())
+    assert conn.attempts == ["https://mcp.example.test/sse"]


### PR DESCRIPTION
Closes #80

## 关联 Issue

Closes #80

## 改动说明

修复 `micro_agent/simulation/service_tool_session.py` 中的 SSRF (CWE-918)。

未认证的 `POST /api/agent/simulation/start` 端点会把请求体中 `servicesMeta[*].mcpUrl` 原样传给 `ServiceToolSession._add_mcp`，进而由 MCP 客户端发起 SSE / streamable-HTTP 出站连接。攻击者只要能访问 API 端口（默认 `uvicorn ... --host 0.0.0.0`，且 CORS 为 `*`，路由 / 应用层都没有 `Depends(...)` 认证依赖），就能让服务端主动去请求：

- 云环境元数据 (`http://169.254.169.254/latest/meta-data/...`)
- 本机回环 (`http://127.0.0.1:*/`, `http://localhost/`, `http://[::1]/`)
- 内网 RFC1918 段 (`10/8`, `192.168/16`, `172.16/12`)
- IPv6 链路本地 (`fe80::/10`)

本 PR 在真正建立 MCP 连接前加了一层 URL 校验（新增 `_validate_mcp_endpoint`，与 `_add_mcp` 处调用一次）：

1. `urlsplit` 解析并要求 `http`/`https`；
2. 预先拒绝 `localhost` / `ip6-localhost` 等回环别名（避免依赖 DNS）；
3. `socket.getaddrinfo` 解析后，拒绝任何 IPv4/IPv6 属于 loopback / link-local / private / multicast / reserved / unspecified；
4. 提供两个环境变量给运维放行内网 MCP 服务：
   - `MICRO_AGENT_MCP_ALLOW_HOSTS` — 逗号分隔的主机名白名单；
   - `MICRO_AGENT_MCP_ALLOW_PRIVATE=1` — 放行整个私有段（供可信内网部署）。

校验放在 `ServiceToolSession._add_mcp` 这个唯一的 MCP 建连入口，`orchestrator.SimulationOrchestrator` 和 `artifact_runtime.run_artifact` 两条调用路径都会覆盖到。

## 测试方式

```bash
pytest tests/test_cwe918_mcp_ssrf.py -q
# 7 passed
```

新增的测试用 `RecordingConnection` 替换真实 MCP 连接，覆盖：

- 负例：`127.0.0.1:6379`、`localhost`、`169.254.169.254`、`10.0.0.5`、`192.168.1.1`、`[::1]` — 期望在任何网络 I/O 发生前抛 `ServiceConnectionError`，`conn.attempts == []`。
- 正例：`https://mcp.example.test/sse` — 校验通过，进入连接阶段（在测试里由 fake 抛出，证明"允许的公网主机确实会走到 connect"）。

同时跑了原有 `tests/test_sandbox_routing.py` 相关的 `ServiceToolSession` 用例，未受影响。

## 安全分析

- 数据流：`SimulationStartRequest.servicesMeta` → `SimulationOrchestrator.__init__` → `ServiceToolSession([...])` → `_add_mcp(service)` → `service["mcpUrl"]` → `ServerConfig.server_url` → MCP `connect()`。修复在最后一步之前插入。
- 触发前置条件：只要能到达 API 端口。没有认证、没有网络层的既有防护 —— 检查了 `api/app.py`（无 `Depends`、CORS `*`）、`api/routes/simulation.py`（`APIRouter(prefix="/api/agent/simulation")` 无 `dependencies=`）。
- 提交前尝试证伪：确认路由层与应用层都没有认证依赖；确认 `mcpUrl` 除长度校验外没有其它清洗；确认调用路径上没有别的地方会先校验 host。没有找到能让漏洞不成立的既有缓解。
- 已知残留：单次 DNS 解析 + 客户端二次解析之间存在 DNS-rebinding 窗口。彻底闭合需要把校验时解析到的 IP 固定进连接，属于对 MCP 客户端集成的较大改造；本 PR 先解决主要问题，欢迎后续在此基础上加固。

## Checklist

- [x] 已关联对应 Issue (#80)
- [x] 代码改动已添加测试 (`tests/test_cwe918_mcp_ssrf.py`)
- [x] `pytest` 测试通过