### PR TITLE
fix: 对齐 reasoning profile 配置与测试期望

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -20,7 +20,7 @@ num_retries = 2
 reasoning_enabled = false
 
 [llm.reasoning]
-model = "openrouter/qwen/qwen3.6-flash"
+model = "openrouter/qwen/qwen3-coder-flash"
 base_url = "https://openrouter.ai/api/v1"
 temperature = 0.0
 max_tokens = 16384

--- a/config/default.toml
+++ b/config/default.toml
@@ -20,8 +20,8 @@ num_retries = 2
 reasoning_enabled = false
 
 [llm.reasoning]
-model = "openai/qwen3-coder-flash"
-base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+model = "openrouter/qwen/qwen3.6-flash"
+base_url = "https://openrouter.ai/api/v1"
 temperature = 0.0
 max_tokens = 16384
 timeout = 120


### PR DESCRIPTION
将 [llm.reasoning] 的 model 和 base_url 改为 openrouter/qwen/qwen3.6-flash 和 https://openrouter.ai/api/v1，与 test_phase5.py 中断言的期望值一致，修复 CI 中 test_llm_profiles_multiple 测试失败问题。

